### PR TITLE
feat: 퀴즈 입력 폼 구현

### DIFF
--- a/src/components/@common/button/Button.tsx
+++ b/src/components/@common/button/Button.tsx
@@ -1,0 +1,22 @@
+import { ButtonHTMLAttributes, forwardRef } from 'react';
+import styles from './button.module.scss';
+
+type Size = 'small' | 'large';
+type Color = 'default' | 'primary';
+
+interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+	size?: Size;
+	color?: Color;
+	clickHandler?: () => void;
+}
+
+const Button = forwardRef<HTMLButtonElement, ButtonProps>(function (
+	{ size = 'large', color = 'default', ...props },
+	ref
+) {
+	const className = `${styles.base} ${styles[size]} ${styles[color]}`;
+
+	return <button ref={ref} {...props} className={className} />;
+});
+
+export default Button;

--- a/src/components/@common/button/button.module.scss
+++ b/src/components/@common/button/button.module.scss
@@ -1,0 +1,29 @@
+.base {
+	height: var(--button-height);
+	border-radius: 8px;
+	font-size: 1.6rem;
+	font-weight: 600;
+	line-height: 2rem;
+
+	&:hover {
+		opacity: 0.9;
+	}
+}
+
+.large {
+	width: 100%;
+}
+
+.small {
+	width: 150px;
+}
+
+.default {
+	background-color: var(--gray-80);
+	color: var(--black-100);
+}
+
+.primary {
+	background-color: var(--correct);
+	color: var(--white-100);
+}

--- a/src/components/@common/button/index.ts
+++ b/src/components/@common/button/index.ts
@@ -1,0 +1,3 @@
+import Button from './Button';
+
+export default Button;

--- a/src/components/@common/index.ts
+++ b/src/components/@common/index.ts
@@ -1,0 +1,3 @@
+export { default as Navbar } from '@components/@common/navbar';
+export { default as InputLabel } from '@components/@common/inputLabel';
+export { default as Input } from '@components/@common/input';

--- a/src/components/@common/input/Input.tsx
+++ b/src/components/@common/input/Input.tsx
@@ -1,0 +1,19 @@
+import { InputHTMLAttributes, forwardRef } from 'react';
+import styles from './input.module.scss';
+
+type Mode = 'text';
+
+interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
+	mode?: Mode;
+}
+
+const Input = forwardRef<HTMLInputElement, InputProps>(function (
+	{ mode, ...props },
+	ref
+) {
+	const className = `${styles.base} ${mode ? styles[mode] : ''}`;
+
+	return <input ref={ref} {...props} className={className} />;
+});
+
+export default Input;

--- a/src/components/@common/input/index.ts
+++ b/src/components/@common/input/index.ts
@@ -1,0 +1,3 @@
+import Input from './Input';
+
+export default Input;

--- a/src/components/@common/input/input.module.scss
+++ b/src/components/@common/input/input.module.scss
@@ -1,0 +1,11 @@
+.base {
+	height: 40px;
+	border: none;
+	outline: none;
+}
+
+.text {
+	border-bottom: 1px solid var(--black-80);
+	font-size: 1.6rem;
+	line-height: 2rem;
+}

--- a/src/components/@common/inputLabel/InputLabel.tsx
+++ b/src/components/@common/inputLabel/InputLabel.tsx
@@ -1,0 +1,20 @@
+import styles from './inputLabel.module.scss';
+
+interface InputLabelProps {
+	title: string;
+	htmlFor: string;
+	element: JSX.Element;
+}
+
+const InputLabel = ({ title, element, htmlFor }: InputLabelProps) => {
+	return (
+		<div className={styles.wrapper}>
+			<label className={styles.title} htmlFor={htmlFor}>
+				{title}
+			</label>
+			{element}
+		</div>
+	);
+};
+
+export default InputLabel;

--- a/src/components/@common/inputLabel/InputLabel.tsx
+++ b/src/components/@common/inputLabel/InputLabel.tsx
@@ -1,18 +1,18 @@
+import { PropsWithChildren } from 'react';
 import styles from './inputLabel.module.scss';
 
-interface InputLabelProps {
+interface InputLabelProps extends PropsWithChildren {
 	title: string;
 	htmlFor: string;
-	element: JSX.Element;
 }
 
-const InputLabel = ({ title, element, htmlFor }: InputLabelProps) => {
+const InputLabel = ({ title, children, htmlFor }: InputLabelProps) => {
 	return (
 		<div className={styles.wrapper}>
 			<label className={styles.title} htmlFor={htmlFor}>
 				{title}
 			</label>
-			{element}
+			{children}
 		</div>
 	);
 };

--- a/src/components/@common/inputLabel/index.ts
+++ b/src/components/@common/inputLabel/index.ts
@@ -1,0 +1,3 @@
+import InputLabel from './InputLabel';
+
+export default InputLabel;

--- a/src/components/@common/inputLabel/inputLabel.module.scss
+++ b/src/components/@common/inputLabel/inputLabel.module.scss
@@ -1,0 +1,10 @@
+.wrapper {
+	display: flex;
+	flex-direction: column;
+	gap: 16px;
+}
+
+.title {
+	font-size: 1.6rem;
+	line-height: 2rem;
+}

--- a/src/components/@common/navbar/Navbar.tsx
+++ b/src/components/@common/navbar/Navbar.tsx
@@ -9,13 +9,13 @@ const Navbar = () => {
 	return (
 		<nav className={styles.wrapper}>
 			<div>
-				<Link className={styles.link} to={URL_PATH.QUIZ_FORM}>
+				<Link className={styles.link} to={URL_PATH.HOME}>
 					<img src={Quiz} alt='문제 풀기' width={24} height={24} />
 					문제 풀기
 				</Link>
 			</div>
 			<div>
-				<Link className={styles.link} to={URL_PATH.REGISTER}>
+				<Link className={styles.link} to={URL_PATH.QUIZ_FORM}>
 					<img src={Plus} alt='문제 등록하기' width={24} height={24} />
 					문제 등록하기
 				</Link>

--- a/src/components/@common/navbar/index.ts
+++ b/src/components/@common/navbar/index.ts
@@ -1,0 +1,3 @@
+import Navbar from './Navbar';
+
+export default Navbar;

--- a/src/components/@common/navbar/navbar.module.scss
+++ b/src/components/@common/navbar/navbar.module.scss
@@ -6,6 +6,8 @@
 	align-items: center;
 	justify-content: space-around;
 	width: 100%;
+	min-width: var(--min-device-width);
+	max-width: var(--max-device-width);
 	height: var(--button-height);
 	border-top: 1px solid var(--black-80);
 }

--- a/src/components/@common/navbar/navbar.module.scss
+++ b/src/components/@common/navbar/navbar.module.scss
@@ -8,7 +8,7 @@
 	width: 100%;
 	min-width: var(--min-device-width);
 	max-width: var(--max-device-width);
-	height: var(--button-height);
+	height: 60px;
 	border-top: 1px solid var(--black-80);
 }
 

--- a/src/components/@common/radio/Radio.tsx
+++ b/src/components/@common/radio/Radio.tsx
@@ -1,16 +1,34 @@
 import styles from './radio.module.scss';
 
+interface Option {
+	title: string;
+	value: React.InputHTMLAttributes<HTMLInputElement>['value'];
+}
 interface RadioProps {
-	options: string[];
-	changeHandler?: () => void;
+	options: Option[];
+	changeHandler?: React.ChangeEventHandler<HTMLInputElement>;
+	required?: boolean;
+	name: string;
 }
 
-const Radio = ({ options }: RadioProps) => {
-	const radioOptions = options.map((value) => (
-		<div key={value} className={styles['label-container']}>
-			<label htmlFor={value}>
-				<input id={value} value={value} type='radio' name='radio' />
-				{value}
+const Radio = ({
+	options,
+	required = false,
+	name,
+	changeHandler,
+}: RadioProps) => {
+	const radioOptions = options.map(({ value, title }) => (
+		<div key={title} className={styles['label-container']}>
+			<label htmlFor={title}>
+				<input
+					id={title}
+					value={value}
+					type='radio'
+					name={name}
+					onChange={changeHandler}
+					required={required}
+				/>
+				{title}
 			</label>
 		</div>
 	));

--- a/src/components/@common/radio/Radio.tsx
+++ b/src/components/@common/radio/Radio.tsx
@@ -1,0 +1,21 @@
+import styles from './radio.module.scss';
+
+interface RadioProps {
+	options: string[];
+	changeHandler?: () => void;
+}
+
+const Radio = ({ options }: RadioProps) => {
+	const radioOptions = options.map((value) => (
+		<div key={value} className={styles['label-container']}>
+			<label htmlFor={value}>
+				<input id={value} value={value} type='radio' name='radio' />
+				{value}
+			</label>
+		</div>
+	));
+
+	return <div className={styles.wrapper}>{radioOptions}</div>;
+};
+
+export default Radio;

--- a/src/components/@common/radio/index.ts
+++ b/src/components/@common/radio/index.ts
@@ -1,0 +1,3 @@
+import Radio from './Radio';
+
+export default Radio;

--- a/src/components/@common/radio/radio.module.scss
+++ b/src/components/@common/radio/radio.module.scss
@@ -1,0 +1,20 @@
+.wrapper {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	justify-content: space-around;
+}
+
+.label-container {
+	display: flex;
+	align-items: center;
+
+	input {
+		margin: 4px;
+	}
+
+	label {
+		font-size: 1.6rem;
+		line-height: 2rem;
+	}
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,1 +1,0 @@
-export { default as Navbar } from '@components/@common/navbar/Navbar';

--- a/src/constants/path.ts
+++ b/src/constants/path.ts
@@ -1,14 +1,14 @@
 export const URL_PATH = {
-	QUIZ_FORM: '/',
+	HOME: '/',
+	QUIZ_FORM: '/quiz-form',
 	QUIZ: '/quiz/:id', // quiz 번호를 의미함
 	QUIZ_EDIT: '/quiz/edit/:id',
-	REGISTER: '/register',
 	CATEGORY: '/category',
 	CATEGORY_DETAIL: '/category/:id', // 여기서 id는 카테고리를 의미함
 };
 
 export const NAVBAR_PAGE = [
+	URL_PATH.HOME,
 	URL_PATH.CATEGORY,
-	URL_PATH.QUIZ_FORM,
 	URL_PATH.CATEGORY_DETAIL,
 ];

--- a/src/constants/quiz.ts
+++ b/src/constants/quiz.ts
@@ -1,0 +1,8 @@
+import { Quiz } from '@models/quiz';
+
+export const INITIAL_QUIZ: Quiz = {
+	quiz: '',
+	answer: false,
+	explain: '',
+	favorite: false,
+};

--- a/src/index.scss
+++ b/src/index.scss
@@ -27,7 +27,7 @@ body::-webkit-scrollbar {
 	--correct: #1bcc66;
 	--accent: #eb4d3d;
 	--sky: #63c5da;
-	--button-height: 60px;
+	--button-height: 40px;
 	--min-device-width: 320px;
 	--max-device-width: 720px;
 	--dropdown-backdrop: 1000;

--- a/src/models/quiz.ts
+++ b/src/models/quiz.ts
@@ -1,0 +1,6 @@
+export interface Quiz {
+	quiz: string;
+	explain: string;
+	answer: boolean;
+	favorite: boolean;
+}

--- a/src/pages/QuizRegister/QuizRegister.tsx
+++ b/src/pages/QuizRegister/QuizRegister.tsx
@@ -1,0 +1,120 @@
+import { Input, InputLabel } from '@components/@common';
+import styles from './quizRegister.module.scss';
+import Button from '@components/@common/button';
+import Radio from '@components/@common/radio';
+import { useNavigate } from 'react-router-dom';
+import { URL_PATH } from '@constants/path';
+import { useState } from 'react';
+import { Quiz } from '@models/quiz';
+import { INITIAL_QUIZ } from '@constants/quiz';
+
+const QuizRegister = () => {
+	const navigate = useNavigate();
+
+	const cancelHandler: React.MouseEventHandler<HTMLButtonElement> = () => {
+		const result = confirm(
+			'여기서 취소하면 작성한 내용이 사라집니다. 취소하시겠습니까?'
+		);
+
+		if (result) {
+			navigate(URL_PATH.HOME);
+		}
+	};
+
+	const [quizState, setQuizState] = useState<Quiz>(INITIAL_QUIZ);
+
+	const inputHandler = <T extends HTMLInputElement | HTMLTextAreaElement>(
+		event: React.ChangeEvent<T>
+	) => {
+		if (!(event instanceof HTMLInputElement || HTMLTextAreaElement)) return;
+
+		const { name, value, type } = event.target;
+
+		setQuizState((prev) => ({
+			...prev,
+			[name]: type === 'radio' ? Boolean(Number(value)) : value,
+		}));
+	};
+
+	const submitHandler: React.FormEventHandler<HTMLFormElement> = (event) => {
+		event.preventDefault();
+	};
+
+	return (
+		<main className={styles.main} onSubmit={submitHandler}>
+			<form className={styles['quiz-form']}>
+				<InputLabel
+					title='문제'
+					element={
+						<Input
+							id='quiz'
+							mode='text'
+							name='quiz'
+							value={quizState.quiz}
+							onChange={inputHandler}
+							required
+						/>
+					}
+					htmlFor='quiz'
+				/>
+
+				<InputLabel
+					title='답'
+					htmlFor='answer'
+					element={
+						<Radio
+							options={[
+								{ title: 'O', value: 1 },
+								{ title: 'X', value: 0 },
+							]}
+							name='answer'
+							changeHandler={inputHandler}
+							required
+						/>
+					}
+				/>
+
+				<InputLabel
+					title='해설'
+					element={
+						<textarea
+							className={styles.explain}
+							value={quizState.explain}
+							onChange={inputHandler}
+							name='explain'
+							required
+						/>
+					}
+					htmlFor='explain'
+				/>
+
+				<InputLabel
+					title='즐겨찾기 등록'
+					htmlFor='favorite'
+					element={
+						<Radio
+							options={[
+								{ title: '등록하기', value: 1 },
+								{ title: '등록안함', value: 0 },
+							]}
+							name='favorite'
+							changeHandler={inputHandler}
+							required
+						/>
+					}
+				/>
+
+				<div className={styles['button-container']}>
+					<Button type='button' size='small' onClick={cancelHandler}>
+						취소하기
+					</Button>
+					<Button type='submit' size='small' color='primary'>
+						등록하기
+					</Button>
+				</div>
+			</form>
+		</main>
+	);
+};
+
+export default QuizRegister;

--- a/src/pages/QuizRegister/QuizRegister.tsx
+++ b/src/pages/QuizRegister/QuizRegister.tsx
@@ -43,66 +43,50 @@ const QuizRegister = () => {
 	return (
 		<main className={styles.main} onSubmit={submitHandler}>
 			<form className={styles['quiz-form']}>
-				<InputLabel
-					title='문제'
-					element={
-						<Input
-							id='quiz'
-							mode='text'
-							name='quiz'
-							value={quizState.quiz}
-							onChange={inputHandler}
-							required
-						/>
-					}
-					htmlFor='quiz'
-				/>
+				<InputLabel title='문제' htmlFor='quiz'>
+					<Input
+						id='quiz'
+						mode='text'
+						name='quiz'
+						value={quizState.quiz}
+						onChange={inputHandler}
+						required
+					/>
+				</InputLabel>
 
-				<InputLabel
-					title='답'
-					htmlFor='answer'
-					element={
-						<Radio
-							options={[
-								{ title: 'O', value: 1 },
-								{ title: 'X', value: 0 },
-							]}
-							name='answer'
-							changeHandler={inputHandler}
-							required
-						/>
-					}
-				/>
+				<InputLabel title='답' htmlFor='answer'>
+					<Radio
+						options={[
+							{ title: 'O', value: 1 },
+							{ title: 'X', value: 0 },
+						]}
+						name='answer'
+						changeHandler={inputHandler}
+						required
+					/>
+				</InputLabel>
 
-				<InputLabel
-					title='해설'
-					element={
-						<textarea
-							className={styles.explain}
-							value={quizState.explain}
-							onChange={inputHandler}
-							name='explain'
-							required
-						/>
-					}
-					htmlFor='explain'
-				/>
+				<InputLabel title='해설' htmlFor='explain'>
+					<textarea
+						className={styles.explain}
+						value={quizState.explain}
+						onChange={inputHandler}
+						name='explain'
+						required
+					/>
+				</InputLabel>
 
-				<InputLabel
-					title='즐겨찾기 등록'
-					htmlFor='favorite'
-					element={
-						<Radio
-							options={[
-								{ title: '등록하기', value: 1 },
-								{ title: '등록안함', value: 0 },
-							]}
-							name='favorite'
-							changeHandler={inputHandler}
-							required
-						/>
-					}
-				/>
+				<InputLabel title='즐겨찾기 등록' htmlFor='favorite'>
+					<Radio
+						options={[
+							{ title: '등록하기', value: 1 },
+							{ title: '등록안함', value: 0 },
+						]}
+						name='favorite'
+						changeHandler={inputHandler}
+						required
+					/>
+				</InputLabel>
 
 				<div className={styles['button-container']}>
 					<Button type='button' size='small' onClick={cancelHandler}>

--- a/src/pages/QuizRegister/quizRegister.module.scss
+++ b/src/pages/QuizRegister/quizRegister.module.scss
@@ -1,0 +1,25 @@
+.main {
+	width: 100%;
+	padding: 30px 20px;
+}
+
+.quiz-form {
+	display: flex;
+	flex-direction: column;
+	gap: 48px;
+}
+
+.explain {
+	max-width: var(--max-device-width);
+	height: 240px;
+	font-size: 1.6rem;
+	line-height: 2rem;
+	resize: none;
+}
+
+.button-container {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	gap: 16px;
+}

--- a/src/pages/RootTemplate/RootTemplate.tsx
+++ b/src/pages/RootTemplate/RootTemplate.tsx
@@ -1,4 +1,4 @@
-import { Navbar } from '@components/index';
+import { Navbar } from '@components/@common';
 import { NAVBAR_PAGE } from '@constants/path';
 import { useMemo } from 'react';
 import { Outlet, useLocation } from 'react-router-dom';

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -1,1 +1,2 @@
 export { default as RootTemplate } from './RootTemplate/RootTemplate';
+export { default as QuizRegister } from './QuizRegister/QuizRegister';

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -1,12 +1,18 @@
 import { URL_PATH } from '@constants/path';
 import { createBrowserRouter } from 'react-router-dom';
-import { RootTemplate } from './pages';
+import { QuizRegister, RootTemplate } from './pages';
 
 const router = createBrowserRouter([
 	{
-		path: URL_PATH.QUIZ_FORM,
+		path: URL_PATH.HOME,
 		element: <RootTemplate />,
-		children: [],
+		errorElement: <div>에러입니다</div>,
+		children: [
+			{
+				path: URL_PATH.QUIZ_FORM,
+				element: <QuizRegister />,
+			},
+		],
 	},
 ]);
 


### PR DESCRIPTION
문제 등록 및 정답 그리고 해설과 즐겨찾기 기능을 추가한 기능 구현 완료

테스트 코드작성에 대한 필요성은 아직까지 느끼지 못했지만 차차 도입해 볼 예정

공통 컴포넌트를 만들겠다고 약간 시간 낭비한게 없지않게 있긴 함. 코드 수정은 불가피 할듯

label + input의 조합을 좀더 잘 해볼 것. radio 역시 분할이 가능하고 Element를 props로 받을게 아니라 childrn으로 받으면 더 좋을 것 같음
