### PR TITLE
feat: 퀴즈 업데이트를 구현한다

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -49,11 +49,6 @@ module.exports = {
 						position: 'after',
 					},
 					{
-						pattern: '@class/*',
-						group: 'internal',
-						position: 'after',
-					},
-					{
 						pattern: '@components/*',
 						group: 'internal',
 						position: 'after',
@@ -69,7 +64,7 @@ module.exports = {
 						position: 'after',
 					},
 					{
-						pattern: '@contexts/*',
+						pattern: '@context/*',
 						group: 'internal',
 						position: 'after',
 					},

--- a/index.html
+++ b/index.html
@@ -15,6 +15,7 @@
 	</head>
 	<body>
 		<div id="root"></div>
+		<div id="toast-root"></div>
 		<script type="module" src="/src/main.tsx"></script>
 	</body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
 				"stylelint-config-standard-scss": "^11.1.0",
 				"stylelint-order": "^6.0.3",
 				"stylelint-scss": "^5.3.1",
+				"ts-css-modules-vite-plugin": "^1.0.20",
 				"typescript": "^5.2.2",
 				"typescript-plugin-css-modules": "^5.0.2",
 				"vite": "^5.0.0",
@@ -410,6 +411,28 @@
 			},
 			"engines": {
 				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@cspotcode/source-map-support": {
+			"version": "0.8.1",
+			"resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+			"integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+			"dev": true,
+			"dependencies": {
+				"@jridgewell/trace-mapping": "0.3.9"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+			"integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+			"dev": true,
+			"dependencies": {
+				"@jridgewell/resolve-uri": "^3.0.3",
+				"@jridgewell/sourcemap-codec": "^1.4.10"
 			}
 		},
 		"node_modules/@csstools/css-parser-algorithms": {
@@ -1838,6 +1861,30 @@
 				"react": "^18.0.0"
 			}
 		},
+		"node_modules/@tsconfig/node10": {
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
+			"integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
+			"dev": true
+		},
+		"node_modules/@tsconfig/node12": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+			"integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+			"dev": true
+		},
+		"node_modules/@tsconfig/node14": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+			"integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+			"dev": true
+		},
+		"node_modules/@tsconfig/node16": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+			"integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+			"dev": true
+		},
 		"node_modules/@types/babel__core": {
 			"version": "7.20.5",
 			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -2409,6 +2456,15 @@
 				"acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
 			}
 		},
+		"node_modules/acorn-walk": {
+			"version": "8.3.2",
+			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.2.tgz",
+			"integrity": "sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.4.0"
+			}
+		},
 		"node_modules/ajv": {
 			"version": "6.12.6",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -2467,6 +2523,12 @@
 			"engines": {
 				"node": ">= 8"
 			}
+		},
+		"node_modules/arg": {
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+			"integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+			"dev": true
 		},
 		"node_modules/argparse": {
 			"version": "2.0.1",
@@ -2596,6 +2658,15 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/camelcase-css": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
+			"integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
+			"dev": true,
+			"engines": {
+				"node": ">= 6"
 			}
 		},
 		"node_modules/camelcase-keys": {
@@ -2802,6 +2873,12 @@
 				}
 			}
 		},
+		"node_modules/create-require": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+			"integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+			"dev": true
+		},
 		"node_modules/cross-spawn": {
 			"version": "7.0.3",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -2930,6 +3007,15 @@
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
 			"integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
 			"dev": true
+		},
+		"node_modules/diff": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+			"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.3.1"
+			}
 		},
 		"node_modules/dir-glob": {
 			"version": "3.0.1",
@@ -4295,6 +4381,12 @@
 				"semver": "bin/semver"
 			}
 		},
+		"node_modules/make-error": {
+			"version": "1.3.6",
+			"resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+			"integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+			"dev": true
+		},
 		"node_modules/map-obj": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz",
@@ -4749,6 +4841,25 @@
 			},
 			"engines": {
 				"node": "^10 || ^12 || >=14"
+			}
+		},
+		"node_modules/postcss-js": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.0.1.tgz",
+			"integrity": "sha512-dDLF8pEO191hJMtlHFPRa8xsizHaM82MLfNkUHdUtVEV3tgTp5oj+8qbEqYM57SLfc74KSbw//4SeJma2LRVIw==",
+			"dev": true,
+			"dependencies": {
+				"camelcase-css": "^2.0.1"
+			},
+			"engines": {
+				"node": "^12 || ^14 || >= 16"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/postcss/"
+			},
+			"peerDependencies": {
+				"postcss": "^8.4.21"
 			}
 		},
 		"node_modules/postcss-load-config": {
@@ -6080,6 +6191,60 @@
 				"typescript": ">=4.2.0"
 			}
 		},
+		"node_modules/ts-css-modules-vite-plugin": {
+			"version": "1.0.20",
+			"resolved": "https://registry.npmjs.org/ts-css-modules-vite-plugin/-/ts-css-modules-vite-plugin-1.0.20.tgz",
+			"integrity": "sha512-FlD2dyFAhmfOcmaxWR5WQ7Eu0ypvBwqjxgY54kYpEgpCEBqLAdO/w40h5XZn5zlUKUVjc7f69AIsfuhlGVjBSw==",
+			"dev": true,
+			"dependencies": {
+				"postcss-js": "^4.0.0",
+				"sass": "^1.57.1",
+				"ts-node": "^10.9.1"
+			}
+		},
+		"node_modules/ts-node": {
+			"version": "10.9.2",
+			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+			"integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+			"dev": true,
+			"dependencies": {
+				"@cspotcode/source-map-support": "^0.8.0",
+				"@tsconfig/node10": "^1.0.7",
+				"@tsconfig/node12": "^1.0.7",
+				"@tsconfig/node14": "^1.0.0",
+				"@tsconfig/node16": "^1.0.2",
+				"acorn": "^8.4.1",
+				"acorn-walk": "^8.1.1",
+				"arg": "^4.1.0",
+				"create-require": "^1.1.0",
+				"diff": "^4.0.1",
+				"make-error": "^1.1.1",
+				"v8-compile-cache-lib": "^3.0.1",
+				"yn": "3.1.1"
+			},
+			"bin": {
+				"ts-node": "dist/bin.js",
+				"ts-node-cwd": "dist/bin-cwd.js",
+				"ts-node-esm": "dist/bin-esm.js",
+				"ts-node-script": "dist/bin-script.js",
+				"ts-node-transpile-only": "dist/bin-transpile.js",
+				"ts-script": "dist/bin-script-deprecated.js"
+			},
+			"peerDependencies": {
+				"@swc/core": ">=1.2.50",
+				"@swc/wasm": ">=1.2.50",
+				"@types/node": "*",
+				"typescript": ">=2.7"
+			},
+			"peerDependenciesMeta": {
+				"@swc/core": {
+					"optional": true
+				},
+				"@swc/wasm": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/tsconfck": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-2.1.2.tgz",
@@ -6242,6 +6407,12 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
 			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+			"dev": true
+		},
+		"node_modules/v8-compile-cache-lib": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+			"integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
 			"dev": true
 		},
 		"node_modules/validate-npm-package-license": {
@@ -6614,6 +6785,15 @@
 				"node": ">=12"
 			}
 		},
+		"node_modules/yn": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+			"integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/yocto-queue": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -6903,6 +7083,27 @@
 				"@babel/helper-string-parser": "^7.23.4",
 				"@babel/helper-validator-identifier": "^7.22.20",
 				"to-fast-properties": "^2.0.0"
+			}
+		},
+		"@cspotcode/source-map-support": {
+			"version": "0.8.1",
+			"resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+			"integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+			"dev": true,
+			"requires": {
+				"@jridgewell/trace-mapping": "0.3.9"
+			},
+			"dependencies": {
+				"@jridgewell/trace-mapping": {
+					"version": "0.3.9",
+					"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+					"integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+					"dev": true,
+					"requires": {
+						"@jridgewell/resolve-uri": "^3.0.3",
+						"@jridgewell/sourcemap-codec": "^1.4.10"
+					}
+				}
 			}
 		},
 		"@csstools/css-parser-algorithms": {
@@ -7837,6 +8038,30 @@
 				"@tanstack/query-core": "5.12.1"
 			}
 		},
+		"@tsconfig/node10": {
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
+			"integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
+			"dev": true
+		},
+		"@tsconfig/node12": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+			"integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+			"dev": true
+		},
+		"@tsconfig/node14": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+			"integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+			"dev": true
+		},
+		"@tsconfig/node16": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+			"integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+			"dev": true
+		},
 		"@types/babel__core": {
 			"version": "7.20.5",
 			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -8303,6 +8528,12 @@
 			"dev": true,
 			"requires": {}
 		},
+		"acorn-walk": {
+			"version": "8.3.2",
+			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.2.tgz",
+			"integrity": "sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==",
+			"dev": true
+		},
 		"ajv": {
 			"version": "6.12.6",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -8346,6 +8577,12 @@
 				"normalize-path": "^3.0.0",
 				"picomatch": "^2.0.4"
 			}
+		},
+		"arg": {
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+			"integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+			"dev": true
 		},
 		"argparse": {
 			"version": "2.0.1",
@@ -8431,6 +8668,12 @@
 			"version": "6.3.0",
 			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
 			"integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+			"dev": true
+		},
+		"camelcase-css": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
+			"integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
 			"dev": true
 		},
 		"camelcase-keys": {
@@ -8575,6 +8818,12 @@
 				"path-type": "^4.0.0"
 			}
 		},
+		"create-require": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+			"integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+			"dev": true
+		},
 		"cross-spawn": {
 			"version": "7.0.3",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -8663,6 +8912,12 @@
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
 			"integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+			"dev": true
+		},
+		"diff": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+			"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
 			"dev": true
 		},
 		"dir-glob": {
@@ -9704,6 +9959,12 @@
 				}
 			}
 		},
+		"make-error": {
+			"version": "1.3.6",
+			"resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+			"integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+			"dev": true
+		},
 		"map-obj": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz",
@@ -10021,6 +10282,15 @@
 				"nanoid": "^3.3.7",
 				"picocolors": "^1.0.0",
 				"source-map-js": "^1.0.2"
+			}
+		},
+		"postcss-js": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.0.1.tgz",
+			"integrity": "sha512-dDLF8pEO191hJMtlHFPRa8xsizHaM82MLfNkUHdUtVEV3tgTp5oj+8qbEqYM57SLfc74KSbw//4SeJma2LRVIw==",
+			"dev": true,
+			"requires": {
+				"camelcase-css": "^2.0.1"
 			}
 		},
 		"postcss-load-config": {
@@ -10912,6 +11182,38 @@
 			"dev": true,
 			"requires": {}
 		},
+		"ts-css-modules-vite-plugin": {
+			"version": "1.0.20",
+			"resolved": "https://registry.npmjs.org/ts-css-modules-vite-plugin/-/ts-css-modules-vite-plugin-1.0.20.tgz",
+			"integrity": "sha512-FlD2dyFAhmfOcmaxWR5WQ7Eu0ypvBwqjxgY54kYpEgpCEBqLAdO/w40h5XZn5zlUKUVjc7f69AIsfuhlGVjBSw==",
+			"dev": true,
+			"requires": {
+				"postcss-js": "^4.0.0",
+				"sass": "^1.57.1",
+				"ts-node": "^10.9.1"
+			}
+		},
+		"ts-node": {
+			"version": "10.9.2",
+			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+			"integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+			"dev": true,
+			"requires": {
+				"@cspotcode/source-map-support": "^0.8.0",
+				"@tsconfig/node10": "^1.0.7",
+				"@tsconfig/node12": "^1.0.7",
+				"@tsconfig/node14": "^1.0.0",
+				"@tsconfig/node16": "^1.0.2",
+				"acorn": "^8.4.1",
+				"acorn-walk": "^8.1.1",
+				"arg": "^4.1.0",
+				"create-require": "^1.1.0",
+				"diff": "^4.0.1",
+				"make-error": "^1.1.1",
+				"v8-compile-cache-lib": "^3.0.1",
+				"yn": "3.1.1"
+			}
+		},
 		"tsconfck": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-2.1.2.tgz",
@@ -11016,6 +11318,12 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
 			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+			"dev": true
+		},
+		"v8-compile-cache-lib": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+			"integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
 			"dev": true
 		},
 		"validate-npm-package-license": {
@@ -11248,6 +11556,12 @@
 			"version": "20.2.9",
 			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
 			"integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+			"dev": true
+		},
+		"yn": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+			"integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
 			"dev": true
 		},
 		"yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
 		"stylelint-config-standard-scss": "^11.1.0",
 		"stylelint-order": "^6.0.3",
 		"stylelint-scss": "^5.3.1",
+		"ts-css-modules-vite-plugin": "^1.0.20",
 		"typescript": "^5.2.2",
 		"typescript-plugin-css-modules": "^5.0.2",
 		"vite": "^5.0.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,16 +3,21 @@ import router from './router';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ToastProvider } from '@context/ToastProvider';
 import { ToastList } from '@components/@common';
+import { ConfirmProvider } from '@context/ConfirmProvider';
+import Confirm from '@components/@common/confirm/Confirm';
 
 const queryClient = new QueryClient();
 
 function App() {
 	return (
 		<QueryClientProvider client={queryClient}>
-			<ToastProvider>
-				<RouterProvider router={router} />
-				<ToastList />
-			</ToastProvider>
+			<ConfirmProvider>
+				<ToastProvider>
+					<RouterProvider router={router} />
+					<ToastList />
+					<Confirm />
+				</ToastProvider>
+			</ConfirmProvider>
 		</QueryClientProvider>
 	);
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,13 +1,18 @@
 import { RouterProvider } from 'react-router-dom';
 import router from './router';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ToastProvider } from '@context/ToastProvider';
+import { ToastList } from '@components/@common';
 
 const queryClient = new QueryClient();
 
 function App() {
 	return (
 		<QueryClientProvider client={queryClient}>
-			<RouterProvider router={router} />
+			<ToastProvider>
+				<RouterProvider router={router} />
+				<ToastList />
+			</ToastProvider>
 		</QueryClientProvider>
 	);
 }

--- a/src/components/@common/confirm/Confirm.tsx
+++ b/src/components/@common/confirm/Confirm.tsx
@@ -1,0 +1,41 @@
+import useConfirmState from '@hooks/useConformState';
+import useConfirmModal from '@hooks/useConfirmModal';
+import styles from './confirm.module.scss';
+
+const Confirm = () => {
+	const { confirmState } = useConfirmState();
+	const modalRef = useConfirmModal();
+
+	const { isOpen, title, message, setAnswer } = confirmState;
+
+	return (
+		isOpen && (
+			<dialog
+				className={styles['confirm-box']}
+				ref={modalRef}
+				key={Math.random()}
+			>
+				{title && <h2 className={styles['title']}>{title}</h2>}
+				<p className={styles['message']}>{message}</p>
+				<div className={styles['button-area']}>
+					<button
+						className={styles['primary-button']}
+						type='button'
+						onClick={() => setAnswer?.(true)}
+					>
+						네
+					</button>
+					<button
+						className={styles['secondary-button']}
+						type='button'
+						onClick={() => setAnswer?.(false)}
+					>
+						아니오
+					</button>
+				</div>
+			</dialog>
+		)
+	);
+};
+
+export default Confirm;

--- a/src/components/@common/confirm/confirm.module.scss
+++ b/src/components/@common/confirm/confirm.module.scss
@@ -1,0 +1,75 @@
+/* stylelint-disable keyframes-name-pattern */
+@use '../../../style/variables' as v;
+@use '../../../style/mixin' as m;
+
+@keyframes alert {
+	0% {
+		transform: rotate(1deg);
+	}
+
+	25% {
+		transform: rotate(0deg);
+	}
+
+	50% {
+		transform: rotate(-1deg);
+	}
+
+	100% {
+		transform: rotate(0deg);
+	}
+}
+
+.confirm-box {
+	@include m.modalBox;
+
+	display: flex;
+	top: calc(50vh - 50%);
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	width: 90%;
+	max-width: #{v.$mid-device-width};
+	margin: auto;
+	padding: 30px 0;
+	animation: alert 0.15s linear 2;
+	row-gap: 20px;
+
+	&::backdrop {
+		cursor: default;
+	}
+}
+
+.title {
+	@include m.confirmText;
+	@include m.fontMedium;
+}
+
+.message {
+	@include m.confirmText;
+	@include m.fontSmall;
+}
+
+.button-area {
+	display: flex;
+	width: calc(100% - 50px);
+	min-width: calc(#{v.$min-device-width} - 50px);
+	max-width: calc(#{v.$mid-device-width} - 50px);
+	padding: 0 30px;
+	column-gap: 30px;
+}
+
+.primary-button {
+	@include m.confirmButton;
+
+	background: #{v.$correct};
+	color: #{v.$white-100};
+}
+
+.secondary-button {
+	@include m.confirmButton;
+
+	border: 1px solid #{v.$correct};
+	background: #{v.$white-100};
+	color: #{v.$black-80};
+}

--- a/src/components/@common/confirm/index.ts
+++ b/src/components/@common/confirm/index.ts
@@ -1,0 +1,3 @@
+import Confirm from './Confirm';
+
+export default Confirm;

--- a/src/components/@common/favoriteButton/FavoriteButton.tsx
+++ b/src/components/@common/favoriteButton/FavoriteButton.tsx
@@ -1,0 +1,23 @@
+import StarFill from '@assets/star_fill.svg';
+import StarEmpty from '@assets/star_empty.svg';
+import { ButtonHTMLAttributes } from 'react';
+
+interface FavoriteButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+	isFavorite: boolean;
+}
+
+const FavoriteButton = (props: FavoriteButtonProps) => {
+	const { isFavorite, onClick } = props;
+	return (
+		<button type='button' onClick={onClick}>
+			<img
+				src={isFavorite ? StarFill : StarEmpty}
+				width={24}
+				height={24}
+				alt='즐겨찾기 등록/해제'
+			/>
+		</button>
+	);
+};
+
+export default FavoriteButton;

--- a/src/components/@common/favoriteButton/index.ts
+++ b/src/components/@common/favoriteButton/index.ts
@@ -1,0 +1,3 @@
+import FavoriteButton from './FavoriteButton';
+
+export default FavoriteButton;

--- a/src/components/@common/index.ts
+++ b/src/components/@common/index.ts
@@ -3,3 +3,8 @@ export { default as InputLabel } from '@components/@common/inputLabel';
 export { default as Input } from '@components/@common/input';
 export { default as Header } from '@components/@common/header';
 export { default as ToastList } from '@components/@common/toast';
+export { default as Button } from '@components/@common/button';
+export { default as FavoriteButton } from '@components/@common/favoriteButton';
+export { default as Spinner } from '@components/@common/spinner';
+export { default as Confirm } from '@components/@common/confirm';
+export { default as Radio } from '@components/@common/radio';

--- a/src/components/@common/index.ts
+++ b/src/components/@common/index.ts
@@ -2,3 +2,4 @@ export { default as Navbar } from '@components/@common/navbar';
 export { default as InputLabel } from '@components/@common/inputLabel';
 export { default as Input } from '@components/@common/input';
 export { default as Header } from '@components/@common/header';
+export { default as ToastList } from '@components/@common/toast';

--- a/src/components/@common/radio/Radio.tsx
+++ b/src/components/@common/radio/Radio.tsx
@@ -9,6 +9,7 @@ interface RadioProps {
 	changeHandler?: React.ChangeEventHandler<HTMLInputElement>;
 	required?: boolean;
 	name: string;
+	checkedValue?: React.InputHTMLAttributes<HTMLInputElement>['value'];
 }
 
 const Radio = ({
@@ -16,22 +17,28 @@ const Radio = ({
 	required = false,
 	name,
 	changeHandler,
+	checkedValue,
 }: RadioProps) => {
-	const radioOptions = options.map(({ value, title }) => (
-		<div key={title} className={styles['label-container']}>
-			<label htmlFor={title}>
-				<input
-					id={title}
-					value={value}
-					type='radio'
-					name={name}
-					onChange={changeHandler}
-					required={required}
-				/>
-				{title}
-			</label>
-		</div>
-	));
+	const radioOptions = options.map(({ value, title }) => {
+		const checked = checkedValue === value;
+
+		return (
+			<div key={title} className={styles['label-container']}>
+				<label htmlFor={title}>
+					<input
+						id={title}
+						value={value}
+						type='radio'
+						name={name}
+						onChange={changeHandler}
+						required={required}
+						checked={checked}
+					/>
+					{title}
+				</label>
+			</div>
+		);
+	});
 
 	return <div className={styles.wrapper}>{radioOptions}</div>;
 };

--- a/src/components/@common/toast/Toast.tsx
+++ b/src/components/@common/toast/Toast.tsx
@@ -1,0 +1,52 @@
+import { memo, useEffect, useState, useCallback, useRef } from 'react';
+import { ToastItem } from '@context/ToastProvider';
+import useToast from '@hooks/useToast';
+import styles from './toast.module.scss';
+
+const Toast = (props: ToastItem) => {
+	const { id, type, message, time = 2100 } = props;
+
+	const { setToastItem } = useToast();
+
+	const [visible, setVisible] = useState(true);
+	const timeoutId = useRef(0);
+
+	const toastClose = useCallback(() => {
+		setVisible(false);
+		setTimeout(() => {
+			setToastItem((prev) => prev.filter(({ id: toastId }) => toastId !== id));
+		}, 200);
+	}, [id]);
+
+	useEffect(() => {
+		timeoutId.current = self.setTimeout(toastClose, time);
+
+		return () => {
+			if (timeoutId.current) clearTimeout(timeoutId.current);
+		};
+	}, [time, toastClose]);
+
+	return (
+		<div
+			className={`
+			${styles['wrapper']}
+			${styles[`${type}-border`]}
+			${styles[`animation-${visible ? 'show' : 'hide'}`]}
+			`}
+			role='alert'
+		>
+			<div className={`${styles['left-aria']}`}>
+				<div className={`${styles['content-area']}`}>
+					<div className={`${styles['message-area']}`}>
+						<p>{message}</p>
+					</div>
+				</div>
+			</div>
+			<div
+				className={`${styles['progress-bar']} ${styles[`${type}-border`]}`}
+			/>
+		</div>
+	);
+};
+
+export default memo(Toast);

--- a/src/components/@common/toast/ToastList.tsx
+++ b/src/components/@common/toast/ToastList.tsx
@@ -1,0 +1,28 @@
+import { Fragment, useMemo } from 'react';
+import { createPortal } from 'react-dom';
+import useToast from '@hooks/useToast';
+import Toast from './Toast';
+import styles from './toast.module.scss';
+
+const ToastList = () => {
+	const { toastItem } = useToast();
+	const root = document.getElementById('toast-root') ?? document.body;
+
+	const toastItems = useMemo(
+		() => toastItem.map((props) => <Toast key={props.id} {...props} />),
+		[toastItem]
+	);
+
+	return createPortal(
+		<Fragment>
+			{toastItem.length > 0 && (
+				<div className={styles['toast-list-wrapper']} aria-live='assertive'>
+					{toastItems}
+				</div>
+			)}
+		</Fragment>,
+		root
+	);
+};
+
+export default ToastList;

--- a/src/components/@common/toast/index.ts
+++ b/src/components/@common/toast/index.ts
@@ -1,0 +1,3 @@
+import ToastList from './ToastList';
+
+export default ToastList;

--- a/src/components/@common/toast/toast.module.scss
+++ b/src/components/@common/toast/toast.module.scss
@@ -1,0 +1,138 @@
+/* stylelint-disable keyframes-name-pattern */
+/* stylelint-disable scss/no-global-function-names */
+@use '../../../style/variables' as v;
+
+$borderColors: (
+	info: #{v.$sky},
+	success: #{v.$correct},
+	warning: #{v.$gray-100},
+	error: #{v.$accent},
+);
+
+.info-border {
+	border: solid 1px map-get($borderColors, info);
+	background-color: map-get($borderColors, info) + 'aa';
+}
+
+.success-border {
+	border: solid 1px map-get($borderColors, success);
+	background-color: map-get($borderColors, success) + 'aa';
+}
+
+.warning-border {
+	border: solid 1px map-get($borderColors, warning);
+	background-color: map-get($borderColors, warning) + 'aa';
+}
+
+.error-border {
+	border: solid 1px map-get($borderColors, error);
+	background-color: map-get($borderColors, error) + 'aa';
+}
+
+.animation-show {
+	transform: scale(100%);
+	transition: all 2s;
+	animation: show 0.2s ease-out alternate;
+}
+
+.animation-hide {
+	transform: scale(100%);
+	transition: all 2s;
+	animation: hide 0.2s ease-out alternate;
+}
+
+@keyframes show {
+	0% {
+		transform: translateY(50%);
+		opacity: 0.4;
+	}
+
+	100% {
+		transform: translateY(0);
+		opacity: 1;
+	}
+}
+
+@keyframes hide {
+	0% {
+		transform: translateY(0%);
+		opacity: 1;
+	}
+
+	100% {
+		transform: translateY(-100%);
+		opacity: 0;
+	}
+}
+
+@keyframes fill {
+	0% {
+		transform: translateX(-100%);
+	}
+
+	100% {
+		transform: translateX(0);
+	}
+}
+
+.wrapper {
+	display: flex;
+	position: absolute;
+	bottom: 0;
+	align-items: center;
+	justify-content: space-between;
+	width: 80%;
+	max-width: 300px;
+	height: max-content;
+	padding: 8px 16px;
+	overflow: hidden;
+	border-radius: 8px;
+	background-color: #{v.$white-100};
+	box-shadow: 0 0 8px #{v.$gray-100}+ '33';
+	color: #{v.$white-100} + 'e3';
+	backdrop-filter: blur(1px);
+}
+
+.left-aria {
+	display: flex;
+	justify-content: space-between;
+	width: calc(100% - 32px);
+	gap: 8px;
+}
+
+.content-area {
+	display: flex;
+	flex-direction: column;
+	align-items: flex-end;
+	justify-content: center;
+	width: 88%;
+	padding: 4px 0;
+}
+
+.message-area {
+	width: 100%;
+	font-size: 1.6rem;
+	font-weight: 400;
+	line-height: 2rem;
+}
+
+.progress-bar {
+	position: absolute;
+	bottom: 0;
+	left: 0;
+	width: 100%;
+	height: 4px;
+	animation: fill 2000ms;
+	border-radius: 2px;
+}
+
+.toast-list-wrapper {
+	display: flex;
+	position: fixed;
+	z-index: #{v.$popover};
+	bottom: 68px;
+	flex-direction: column;
+	align-items: center;
+	width: 100%;
+	row-gap: 8px;
+}

--- a/src/components/@common/toast/toast.module.scss
+++ b/src/components/@common/toast/toast.module.scss
@@ -60,7 +60,7 @@ $borderColors: (
 	}
 
 	100% {
-		transform: translateY(-100%);
+		transform: translateY(50%);
 		opacity: 0;
 	}
 }
@@ -112,7 +112,7 @@ $borderColors: (
 .message-area {
 	width: 100%;
 	font-size: 1.6rem;
-	font-weight: 400;
+	font-weight: 00;
 	line-height: 2rem;
 }
 

--- a/src/components/quiz/quizDetail/QuizDetail.tsx
+++ b/src/components/quiz/quizDetail/QuizDetail.tsx
@@ -1,13 +1,12 @@
 import useToggle from '@hooks/useToggle';
 import styles from './quizDetail.module.scss';
 import type { QuizInfo } from '@models/quiz';
-import StarFill from '@assets/star_fill.svg';
-import StarEmpty from '@assets/star_empty.svg';
 import useGetDocument from '@hooks/fireStore/useGetDocument';
 import { useQueryClient } from '@tanstack/react-query';
 import useUpdateDocument from '@hooks/fireStore/useUpdateDocument';
 import { QUIZ_PATH } from '@constants/path';
 import useToast from '@hooks/useToast';
+import FavoriteButton from '@components/@common/favoriteButton';
 
 interface QuizDetailProps {
 	quizId: QuizInfo['id'];
@@ -23,7 +22,7 @@ const QuizDetail = ({ quizId }: QuizDetailProps) => {
 
 	const queryClient = useQueryClient();
 
-	const { mutate: update } = useUpdateDocument({
+	const { mutate: updateQuiz } = useUpdateDocument({
 		path: `${QUIZ_PATH}/${quizId}`,
 		onSuccess: () => {
 			queryClient.invalidateQueries({
@@ -59,7 +58,7 @@ const QuizDetail = ({ quizId }: QuizDetailProps) => {
 			wrongCount += 1;
 		}
 
-		update({
+		updateQuiz({
 			data: {
 				...quiz,
 				recentCorrect,
@@ -70,15 +69,22 @@ const QuizDetail = ({ quizId }: QuizDetailProps) => {
 		});
 	};
 
+	const favoriteClickHandler = () => {
+		updateQuiz({
+			data: {
+				...quiz,
+				favorite: !quiz.favorite,
+			},
+		});
+	};
+
 	return (
 		<section>
 			<div className={styles['quiz-container']}>
 				<p>{quiz.quiz}</p>
-				<img
-					src={quiz.favorite ? StarFill : StarEmpty}
-					width={24}
-					height={24}
-					alt='즐겨찾기 상태'
+				<FavoriteButton
+					isFavorite={quiz.favorite}
+					onClick={favoriteClickHandler}
 				/>
 			</div>
 

--- a/src/components/quiz/quizDetail/QuizDetail.tsx
+++ b/src/components/quiz/quizDetail/QuizDetail.tsx
@@ -7,12 +7,14 @@ import useGetDocument from '@hooks/fireStore/useGetDocument';
 import { useQueryClient } from '@tanstack/react-query';
 import useUpdateDocument from '@hooks/fireStore/useUpdateDocument';
 import { QUIZ_PATH } from '@constants/path';
+import useToast from '@hooks/useToast';
 
 interface QuizDetailProps {
 	quizId: QuizInfo['id'];
 }
 
 const QuizDetail = ({ quizId }: QuizDetailProps) => {
+	const { addToast } = useToast();
 	const { isOn: explainOn, toggleHandler: explainHandler } = useToggle();
 
 	const { data: quiz } = useGetDocument<QuizInfo>({
@@ -44,10 +46,16 @@ const QuizDetail = ({ quizId }: QuizDetailProps) => {
 		let tryCount = quiz.tryCount + 1;
 
 		if (answer === quiz.answer) {
-			console.log('맞았습니다');
+			addToast({
+				type: 'success',
+				message: '맞았습니다',
+			});
 			recentCorrect = true;
 		} else {
-			console.log('틀렸습니다');
+			addToast({
+				type: 'error',
+				message: '틀렸습니다',
+			});
 			wrongCount += 1;
 		}
 

--- a/src/components/quiz/quizForm/QuizForm.tsx
+++ b/src/components/quiz/quizForm/QuizForm.tsx
@@ -1,0 +1,110 @@
+import Button from '@components/@common/button';
+import styles from './quizForm.module.scss';
+import { Input, InputLabel } from '@components/@common';
+import Radio from '@components/@common/radio';
+import { INITIAL_QUIZ } from '@constants/quiz';
+import useGetCategory from '@hooks/category/useGetCategory';
+import { QuizFormType, QuizInfo } from '@models/quiz';
+
+interface QuizFormProps {
+	quizState: QuizInfo;
+	type: QuizFormType;
+	cancelHandler: React.MouseEventHandler<HTMLButtonElement>;
+	changeHandler: <
+		T extends HTMLSelectElement | HTMLInputElement | HTMLTextAreaElement
+	>(
+		event: React.ChangeEvent<T>
+	) => void;
+}
+
+const QuizForm = ({
+	quizState,
+	type,
+	cancelHandler,
+	changeHandler,
+}: QuizFormProps) => {
+	const { data: category } = useGetCategory();
+
+	return (
+		<form className={styles['quiz-form']}>
+			<InputLabel title='카테고리' htmlFor='category'>
+				<select
+					className={styles.category}
+					onChange={changeHandler}
+					name='category'
+					value={quizState.category}
+					required
+				>
+					{type === 'add' && (
+						<option hidden disabled value={INITIAL_QUIZ.category}>
+							분류를 선택해주세용
+						</option>
+					)}
+					{category.map(({ id, name }) => (
+						<option key={id} value={id}>
+							{name}
+						</option>
+					))}
+				</select>
+			</InputLabel>
+
+			<InputLabel title='문제' htmlFor='quiz'>
+				<Input
+					id='quiz'
+					mode='text'
+					name='quiz'
+					value={quizState.quiz}
+					onChange={changeHandler}
+					required
+				/>
+			</InputLabel>
+
+			<InputLabel title='답' htmlFor='answer'>
+				<Radio
+					options={[
+						{ title: 'O', value: 1 },
+						{ title: 'X', value: 0 },
+					]}
+					name='answer'
+					changeHandler={changeHandler}
+					checkedValue={Number(quizState.answer)}
+					required
+				/>
+			</InputLabel>
+
+			<InputLabel title='해설' htmlFor='explain'>
+				<textarea
+					className={styles.explain}
+					value={quizState.explain}
+					onChange={changeHandler}
+					name='explain'
+					required
+				/>
+			</InputLabel>
+
+			<InputLabel title='즐겨찾기 등록' htmlFor='favorite'>
+				<Radio
+					options={[
+						{ title: '등록하기', value: 1 },
+						{ title: '등록안함', value: 0 },
+					]}
+					name='favorite'
+					changeHandler={changeHandler}
+					checkedValue={Number(quizState.favorite)}
+					required
+				/>
+			</InputLabel>
+
+			<div className={styles['button-container']}>
+				<Button type='button' size='small' onClick={cancelHandler}>
+					취소하기
+				</Button>
+				<Button type='submit' size='small' color='primary'>
+					등록하기
+				</Button>
+			</div>
+		</form>
+	);
+};
+
+export default QuizForm;

--- a/src/components/quiz/quizForm/QuizForm.tsx
+++ b/src/components/quiz/quizForm/QuizForm.tsx
@@ -100,7 +100,7 @@ const QuizForm = ({
 					취소하기
 				</Button>
 				<Button type='submit' size='small' color='primary'>
-					등록하기
+					{type === 'add' ? '등록하기' : '수정하기'}
 				</Button>
 			</div>
 		</form>

--- a/src/components/quiz/quizForm/index.ts
+++ b/src/components/quiz/quizForm/index.ts
@@ -1,0 +1,3 @@
+import QuizForm from './QuizForm';
+
+export default QuizForm;

--- a/src/components/quiz/quizForm/quizForm.module.scss
+++ b/src/components/quiz/quizForm/quizForm.module.scss
@@ -1,0 +1,26 @@
+@use '../../../style/mixin' as mix;
+
+.quiz-form {
+	display: flex;
+	flex-direction: column;
+	gap: 48px;
+}
+
+.category {
+	height: var(--button-height);
+	@include mix.fontMedium;
+}
+
+.explain {
+	height: 240px;
+	@include mix.fontMedium;
+
+	resize: none;
+}
+
+.button-container {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	gap: 16px;
+}

--- a/src/components/quiz/quizItem/QuizItem.tsx
+++ b/src/components/quiz/quizItem/QuizItem.tsx
@@ -2,10 +2,9 @@ import type { QuizListItem } from '@models/quiz';
 import styles from './quizItem.module.scss';
 import { Link } from 'react-router-dom';
 import { QUIZ_PATH, URL_PATH } from '@constants/path';
-import StarFill from '@assets/star_fill.svg';
-import StarEmpty from '@assets/star_empty.svg';
 import useUpdateDocument from '@hooks/fireStore/useUpdateDocument';
 import { useQueryClient } from '@tanstack/react-query';
+import FavoriteButton from '@components/@common/favoriteButton';
 
 interface QuizItemProps {
 	item: QuizListItem;
@@ -17,7 +16,6 @@ const QuizItem = ({ item, categoryId }: QuizItemProps) => {
 
 	const { mutate: updateQuiz } = useUpdateDocument({
 		path: `${QUIZ_PATH}/${item.id}`,
-		// 여기서 데이터 업데이트 구현하기
 		onSuccess: () => {
 			queryClient.invalidateQueries({
 				queryKey: ['getCategoryQuizList', categoryId],
@@ -45,14 +43,10 @@ const QuizItem = ({ item, categoryId }: QuizItemProps) => {
 				{item.correctRate && (
 					<span>{`${(item.correctRate * 100).toFixed(2)}%`}</span>
 				)}
-				<button type='button' onClick={favoriteClickHandler}>
-					<img
-						src={item.favorite ? StarFill : StarEmpty}
-						width={24}
-						height={24}
-						alt='즐겨찾기 등록/해제'
-					/>
-				</button>
+				<FavoriteButton
+					isFavorite={item.favorite}
+					onClick={favoriteClickHandler}
+				/>
 			</div>
 		</li>
 	);

--- a/src/components/quiz/quizItem/QuizItem.tsx
+++ b/src/components/quiz/quizItem/QuizItem.tsx
@@ -19,7 +19,9 @@ const QuizItem = ({ item, categoryId }: QuizItemProps) => {
 		path: `${QUIZ_PATH}/${item.id}`,
 		// 여기서 데이터 업데이트 구현하기
 		onSuccess: () => {
-			queryClient.invalidateQueries({ queryKey: [categoryId] });
+			queryClient.invalidateQueries({
+				queryKey: ['getCategoryQuizList', categoryId],
+			});
 		},
 	});
 

--- a/src/constants/quiz.ts
+++ b/src/constants/quiz.ts
@@ -2,9 +2,9 @@ import type { Quiz, QuizInfo } from '@models/quiz';
 
 export const INITIAL_QUIZ: Quiz = {
 	quiz: '',
-	answer: false,
+	answer: true,
 	explain: '',
-	favorite: false,
+	favorite: true,
 	category: -1,
 };
 

--- a/src/context/ConfirmProvider.tsx
+++ b/src/context/ConfirmProvider.tsx
@@ -1,0 +1,33 @@
+import { PropsWithChildren, createContext, useState } from 'react';
+
+interface ConfirmState {
+	title: string | null;
+	message: string;
+	isOpen: boolean;
+	setAnswer: ((userAnswer: boolean) => void) | null;
+}
+
+interface ConfirmContextProps {
+	confirmState: ConfirmState;
+	setConfirmState: React.Dispatch<React.SetStateAction<ConfirmState>>;
+}
+
+const INITIAL_CONFIRM: ConfirmState = {
+	title: null,
+	message: '',
+	isOpen: false,
+	setAnswer: null,
+};
+
+export const ConfirmContext = createContext<ConfirmContextProps | null>(null);
+
+export const ConfirmProvider = ({ children }: PropsWithChildren) => {
+	const [confirmState, setConfirmState] =
+		useState<ConfirmState>(INITIAL_CONFIRM);
+
+	return (
+		<ConfirmContext.Provider value={{ confirmState, setConfirmState }}>
+			{children}
+		</ConfirmContext.Provider>
+	);
+};

--- a/src/context/ToastProvider.tsx
+++ b/src/context/ToastProvider.tsx
@@ -1,0 +1,26 @@
+import { PropsWithChildren, createContext, useState } from 'react';
+
+export interface ToastItem {
+	id: string;
+	type: 'info' | 'success' | 'warning' | 'error';
+	message: string;
+	time?: number;
+	buttonContent?: string;
+	onClickButton?: () => void;
+}
+
+interface ToastContextProps {
+	toastItem: ToastItem[];
+	setToastItem: React.Dispatch<React.SetStateAction<ToastItem[]>>;
+}
+
+export const ToastContext = createContext<ToastContextProps | null>(null);
+
+export const ToastProvider = ({ children }: PropsWithChildren) => {
+	const [toastItem, setToastItem] = useState<ToastItem[]>([]);
+	return (
+		<ToastContext.Provider value={{ toastItem, setToastItem }}>
+			{children}
+		</ToastContext.Provider>
+	);
+};

--- a/src/hooks/category/useCategoryInput.ts
+++ b/src/hooks/category/useCategoryInput.ts
@@ -3,10 +3,16 @@ import { useQueryClient } from '@tanstack/react-query';
 import { useState } from 'react';
 import useUpdateDocument from '../fireStore/useUpdateDocument';
 import { CATEGORY_PATH } from '@constants/path';
+import useConfirm from '@hooks/useConfirm';
+import useToast from '@hooks/useToast';
 
 const useCategoryInput = (categories: Category[]) => {
 	const queryClient = useQueryClient();
 	const [categoryInput, setCategoryInput] = useState('');
+
+	const { addToast } = useToast();
+	const confirm = useConfirm();
+
 	const { mutate: addCategory } = useUpdateDocument({
 		path: CATEGORY_PATH,
 		onSuccess() {
@@ -20,19 +26,24 @@ const useCategoryInput = (categories: Category[]) => {
 		setCategoryInput(event.target.value);
 	};
 
-	const addCategoryHandler: React.MouseEventHandler<HTMLButtonElement> = (
+	const addCategoryHandler: React.MouseEventHandler<HTMLButtonElement> = async (
 		event
 	) => {
 		event.preventDefault();
 
 		if (categories.find((val) => val.name === categoryInput)) {
-			alert('이미 존재하는 카테고리입니다. 다시 입력해주세요');
+			addToast({
+				type: 'info',
+				message: '이미 존재하는 카테고리입니다. 다시 입력해주세요',
+			});
+
 			return;
 		}
 
-		const result = confirm(
-			`${categoryInput}으로 입력하면 변경이 불가능합니다. 추가하시겠습니까?`
-		);
+		const result = await confirm({
+			title: '카테고리 추가',
+			message: `${categoryInput}으로 입력하면 변경이 불가능합니다. 추가하시겠습니까?`,
+		});
 
 		if (result) {
 			const date = Date.now();

--- a/src/hooks/fireStore/useGetQuizList.ts
+++ b/src/hooks/fireStore/useGetQuizList.ts
@@ -32,15 +32,20 @@ const useGetQuizList = <V>(
 	let queryKey: unknown[];
 
 	if ('categoryId' in props) {
-		queryKey = [props.categoryId];
+		queryKey = ['getCategoryQuizList', props.categoryId];
 		constrain.push(where('category', '==', props.categoryId));
 	} else {
 		queryKey = [...useGetQuizListQueryKey()];
 		const params = getWholeURLParams();
-
 		// 카테고리 중복 선언 가능
-		if (params['category'] !== undefined) {
-			constrain.push(where('category', 'in', [...params['category']]));
+		if (params['categoryId'] !== undefined) {
+			constrain.push(
+				where(
+					'category',
+					'in',
+					[...params['categoryId'].split(',')].map(Number)
+				)
+			);
 		}
 
 		// 좋아요 확인

--- a/src/hooks/quiz/useQuizForm.ts
+++ b/src/hooks/quiz/useQuizForm.ts
@@ -5,6 +5,7 @@ import { useNavigate } from 'react-router-dom';
 import useAddDocument from '../fireStore/useAddDocument';
 import useUpdateDocument from '@hooks/fireStore/useUpdateDocument';
 import { useQueryClient } from '@tanstack/react-query';
+import useConfirm from '@hooks/useConfirm';
 
 const converter = (type: string, value: string) => {
 	switch (type) {
@@ -29,6 +30,8 @@ const useQuizForm = ({ type, initialData }: QuizFormHookProps) => {
 
 	const queryClient = useQueryClient();
 
+	const confirm = useConfirm();
+
 	const movePrevPage = (type: QuizFormType) => {
 		if (type === 'add') {
 			navigate(URL_PATH.HOME);
@@ -39,10 +42,10 @@ const useQuizForm = ({ type, initialData }: QuizFormHookProps) => {
 
 	const { mutate: addQuiz } = useAddDocument({
 		path: QUIZ_PATH,
-		onSuccess: () => {
-			const answer = confirm(
-				'문제 등록에 성공했습니다 홈으로 이동하시겠습니까?'
-			);
+		onSuccess: async () => {
+			const answer = await confirm({
+				message: '문제 등록에 성공했습니다 홈으로 이동하시겠습니까?',
+			});
 			if (answer) {
 				navigate(URL_PATH.HOME);
 			}
@@ -52,8 +55,10 @@ const useQuizForm = ({ type, initialData }: QuizFormHookProps) => {
 
 	const { mutate: updateQuiz } = useUpdateDocument({
 		path: `${QUIZ_PATH}/${quizState.id}`,
-		onSuccess: () => {
-			const answer = confirm('문제 수정에 성공했습니다!');
+		onSuccess: async () => {
+			const answer = await confirm({
+				message: '문제 수정에 성공했습니다! 이전 페이지로 이동합니다',
+			});
 
 			// 여기서 queryInvalidate 해줌. 문제는 category가 변경되면 어떡하냐... 이거임;;
 			// category가 변경되면 해당 카테고리에 이 quizId는 존재하지 않는게 되어버림.
@@ -68,10 +73,12 @@ const useQuizForm = ({ type, initialData }: QuizFormHookProps) => {
 		},
 	});
 
-	const cancelHandler: React.MouseEventHandler<HTMLButtonElement> = () => {
-		const answer = confirm(
-			'여기서 취소하면 작성한 내용이 사라집니다. 취소하시겠습니까?'
-		);
+	const cancelHandler: React.MouseEventHandler<
+		HTMLButtonElement
+	> = async () => {
+		const answer = await confirm({
+			message: '여기서 취소하면 작성한 내용이 사라집니다. 취소하시겠습니까?',
+		});
 
 		if (answer) {
 			movePrevPage(type);

--- a/src/hooks/quiz/useQuizMenu.ts
+++ b/src/hooks/quiz/useQuizMenu.ts
@@ -5,10 +5,12 @@ import { useQueryClient } from '@tanstack/react-query';
 import useGetQuizListQueryKey from '@hooks/quiz/useGetQuizListQueryKey';
 import useRedirectQuiz from '@hooks/quiz/useRedirectQuiz';
 import { QuizNavbarProps } from '@components/quiz/quizNavbar/QuizNavbar';
+import useConfirm from '@hooks/useConfirm';
 
 const useQuizMenu = ({ quizIds, currentId }: QuizNavbarProps) => {
 	const navigate = useNavigate();
 	const redirectQuizHandler = useRedirectQuiz();
+	const confirm = useConfirm();
 	const queryClient = useQueryClient();
 
 	const queryKey = useGetQuizListQueryKey();
@@ -32,8 +34,10 @@ const useQuizMenu = ({ quizIds, currentId }: QuizNavbarProps) => {
 		navigate(generatePath(URL_PATH.QUIZ_EDIT, { id: currentId }));
 	};
 
-	const deleteClickHandler = () => {
-		const answer = confirm('정말 삭제하시겠습니까?');
+	const deleteClickHandler = async () => {
+		const answer = await confirm({
+			message: '정말 삭제하시겠습니까?',
+		});
 
 		if (answer) {
 			deleteQuiz();

--- a/src/hooks/useConfirm.ts
+++ b/src/hooks/useConfirm.ts
@@ -1,0 +1,52 @@
+import { useCallback } from 'react';
+import useConfirmState from './useConformState';
+
+interface ConfirmParams {
+	message: string;
+	title?: string;
+}
+
+/**
+ * 모달을 통해 사용자의 승인 또는 거절 입력을 유도하는 함수를 반환합니다.
+ *
+ * `window.confirm`과 비슷해요. 버튼 클릭 이외의 상호작용은 불가능합니다.
+ * 하지만 Promise를 반환하기 때문에 .then 또는 await를 사용해야 합니다.
+ * @param confirmText Confirm 창에 담을 내용을 담은 객체
+ * @param confirmText.title 제목 (optional)
+ * @param confirmText.message 내용
+ * @returns 모달을 열고, 사용자의 승인 여부를 담은 Promise를 반환하는 함수
+ */
+const useConfirm = () => {
+	const { setConfirmState } = useConfirmState();
+
+	const confirm = useCallback((confirmText: ConfirmParams) => {
+		const { title = null, message } = confirmText;
+
+		const userAnswer = new Promise<boolean>((resolve) => {
+			const resolveAndClose = (userAnswer: boolean) => {
+				resolve(userAnswer);
+				setConfirmState((prev) => ({ ...prev, isOpen: false }));
+			};
+
+			setConfirmState(({ isOpen: prevIsOpen }) => {
+				if (prevIsOpen)
+					throw new Error(
+						'confirm은 동시에 사용할 수 없습니다. 연속적인 confirm인 경우 await을 사용했는지 확인해주세요 '
+					);
+
+				return {
+					title,
+					message,
+					isOpen: true,
+					setAnswer: resolveAndClose,
+				};
+			});
+		});
+
+		return userAnswer;
+	}, []);
+
+	return confirm;
+};
+
+export default useConfirm;

--- a/src/hooks/useConfirmModal.ts
+++ b/src/hooks/useConfirmModal.ts
@@ -1,0 +1,58 @@
+import { useEffect, useRef } from 'react';
+import useConfirmState from './useConformState';
+
+/**
+ * dialog에 confirm을 위한 이벤트 핸들러들을 추가합니다.
+ *
+ * 1. window.confirm 처럼 backdrop 클릭으로는 닫을 수 없습니다.
+ * 2. Esc 키로 닫을 수 있습니다. 이 떄 유저는 'false'를 고른 것으로 간주합니다.
+ * 3. dialog가 열린 동안에는 스크린 리더로 다른 요소에 접근할 수 없습니다.
+ * 4. dialog가 열린 동안에는 다른 요소를 스크롤할 수 없습니다.
+ *
+ * @returns effect를 걸 dialog를 찍을 ref
+ */
+const useConfirmModal = () => {
+	const modalRef = useRef<HTMLDialogElement>(null);
+	const bodyRef = useRef(document.body);
+	const { confirmState } = useConfirmState();
+
+	const { isOpen, setAnswer } = confirmState;
+
+	useEffect(() => {
+		if (!isOpen) return;
+
+		const dialog = modalRef.current;
+		const body = bodyRef.current;
+
+		if (!dialog || !body) return;
+
+		const close = () => {
+			setAnswer?.(false);
+			dialog.close();
+		};
+
+		const closeOnEsc = (event: KeyboardEvent) => {
+			event.preventDefault();
+
+			if (event.key === 'Escape') {
+				close();
+			}
+		};
+
+		dialog.showModal();
+		body.style.overflowY = 'hidden';
+		window.addEventListener('keydown', closeOnEsc);
+		window.addEventListener('popstate', close);
+
+		return () => {
+			dialog.close();
+			body.style.overflowY = 'auto';
+			window.removeEventListener('keydown', closeOnEsc);
+			window.removeEventListener('popstate', close);
+		};
+	}, [isOpen]);
+
+	return modalRef;
+};
+
+export default useConfirmModal;

--- a/src/hooks/useConformState.ts
+++ b/src/hooks/useConformState.ts
@@ -1,0 +1,16 @@
+import { ConfirmContext } from '@context/ConfirmProvider';
+import { useContext } from 'react';
+
+const useConfirmState = () => {
+	const confirmContext = useContext(ConfirmContext);
+
+	if (confirmContext === null) {
+		throw new Error('ConfirmProvider 내부에서 사용해주세요');
+	}
+
+	const { confirmState, setConfirmState } = confirmContext;
+
+	return { confirmState, setConfirmState };
+};
+
+export default useConfirmState;

--- a/src/hooks/useToast.ts
+++ b/src/hooks/useToast.ts
@@ -1,0 +1,21 @@
+import { ToastContext, ToastItem } from '@context/ToastProvider';
+import { useCallback, useContext } from 'react';
+
+const useToast = () => {
+	const toastContext = useContext(ToastContext);
+
+	if (toastContext === null) {
+		throw new Error('ToastProvider 내부에서 사용해주세요');
+	}
+
+	const { toastItem, setToastItem } = toastContext;
+
+	const addToast = useCallback((props: Omit<ToastItem, 'id'>) => {
+		const id = self.crypto.randomUUID();
+		setToastItem((prev) => [...prev, { ...props, id }]);
+	}, []);
+
+	return { toastItem, addToast, setToastItem };
+};
+
+export default useToast;

--- a/src/models/quiz.ts
+++ b/src/models/quiz.ts
@@ -24,3 +24,5 @@ export type QuizListItem = Omit<
 	QuizInfo,
 	'category' | 'answer' | 'explain' | 'recentCorrect'
 >;
+
+export type QuizFormType = 'edit' | 'add';

--- a/src/pages/Quiz/Quiz.tsx
+++ b/src/pages/Quiz/Quiz.tsx
@@ -21,7 +21,6 @@ const Quiz = () => {
 
 			data.forEach((value) => {
 				const id = value.id;
-
 				result.push(id);
 			});
 			return result;

--- a/src/pages/QuizEdit/QuizEdit.tsx
+++ b/src/pages/QuizEdit/QuizEdit.tsx
@@ -1,0 +1,40 @@
+import QuizForm from '@components/quiz/quizForm';
+import styles from '../QuizRegister/quizRegister.module.scss';
+import useGetDocument from '@hooks/fireStore/useGetDocument';
+import useQuizForm from '@hooks/quiz/useQuizForm';
+import { QuizInfo } from '@models/quiz';
+import { QUIZ_PATH } from '@constants/path';
+import { useParams } from 'react-router-dom';
+
+const QuizEdit = () => {
+	const params = useParams();
+
+	const quizId = params.id;
+
+	if (quizId === undefined) {
+		throw new Error('잘못된 경로입니다');
+	}
+
+	const { data: quiz } = useGetDocument<QuizInfo>({
+		path: `${QUIZ_PATH}/${quizId}`,
+	});
+
+	const { submitHandler, changeHandler, cancelHandler, quizState } =
+		useQuizForm({
+			type: 'edit',
+			initialData: quiz,
+		});
+
+	return (
+		<main className={styles.main} onSubmit={submitHandler}>
+			<QuizForm
+				type='edit'
+				changeHandler={changeHandler}
+				cancelHandler={cancelHandler}
+				quizState={quizState}
+			/>
+		</main>
+	);
+};
+
+export default QuizEdit;

--- a/src/pages/QuizRegister/QuizRegister.tsx
+++ b/src/pages/QuizRegister/QuizRegister.tsx
@@ -1,93 +1,23 @@
-import { Input, InputLabel } from '@components/@common';
 import styles from './quizRegister.module.scss';
-import Button from '@components/@common/button';
-import Radio from '@components/@common/radio';
 import useQuizForm from '@hooks/quiz/useQuizForm';
-import { INITIAL_QUIZ } from '@constants/quiz';
-import useGetCategory from '@hooks/category/useGetCategory';
+import QuizForm from '@components/quiz/quizForm';
+import { INITIAL_QUIZ_RECORD } from '@constants/quiz';
 
 const QuizRegister = () => {
-	const { data: category } = useGetCategory();
-
 	const { submitHandler, changeHandler, cancelHandler, quizState } =
-		useQuizForm();
+		useQuizForm({
+			type: 'add',
+			initialData: INITIAL_QUIZ_RECORD,
+		});
 
 	return (
 		<main className={styles.main} onSubmit={submitHandler}>
-			<form className={styles['quiz-form']}>
-				<InputLabel title='카테고리' htmlFor='category'>
-					<select
-						className={styles.category}
-						onChange={changeHandler}
-						name='category'
-						value={quizState.category}
-						required
-					>
-						<option hidden disabled value={INITIAL_QUIZ.category}>
-							분류를 선택해주세용
-						</option>
-						{category.map(({ id, name }) => (
-							<option key={id} value={id}>
-								{name}
-							</option>
-						))}
-					</select>
-				</InputLabel>
-
-				<InputLabel title='문제' htmlFor='quiz'>
-					<Input
-						id='quiz'
-						mode='text'
-						name='quiz'
-						value={quizState.quiz}
-						onChange={changeHandler}
-						required
-					/>
-				</InputLabel>
-
-				<InputLabel title='답' htmlFor='answer'>
-					<Radio
-						options={[
-							{ title: 'O', value: 1 },
-							{ title: 'X', value: 0 },
-						]}
-						name='answer'
-						changeHandler={changeHandler}
-						required
-					/>
-				</InputLabel>
-
-				<InputLabel title='해설' htmlFor='explain'>
-					<textarea
-						className={styles.explain}
-						value={quizState.explain}
-						onChange={changeHandler}
-						name='explain'
-						required
-					/>
-				</InputLabel>
-
-				<InputLabel title='즐겨찾기 등록' htmlFor='favorite'>
-					<Radio
-						options={[
-							{ title: '등록하기', value: 1 },
-							{ title: '등록안함', value: 0 },
-						]}
-						name='favorite'
-						changeHandler={changeHandler}
-						required
-					/>
-				</InputLabel>
-
-				<div className={styles['button-container']}>
-					<Button type='button' size='small' onClick={cancelHandler}>
-						취소하기
-					</Button>
-					<Button type='submit' size='small' color='primary'>
-						등록하기
-					</Button>
-				</div>
-			</form>
+			<QuizForm
+				type='add'
+				changeHandler={changeHandler}
+				cancelHandler={cancelHandler}
+				quizState={quizState}
+			/>
 		</main>
 	);
 };

--- a/src/pages/QuizRegister/quizRegister.module.scss
+++ b/src/pages/QuizRegister/quizRegister.module.scss
@@ -4,28 +4,3 @@
 	width: 100%;
 	padding: 30px 20px;
 }
-
-.quiz-form {
-	display: flex;
-	flex-direction: column;
-	gap: 48px;
-}
-
-.category {
-	height: var(--button-height);
-	@include mix.fontMedium;
-}
-
-.explain {
-	height: 240px;
-	@include mix.fontMedium;
-
-	resize: none;
-}
-
-.button-container {
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	gap: 16px;
-}

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -7,6 +7,7 @@ import {
 	CategoryDetail,
 	Quiz,
 } from './pages';
+import QuizEdit from '@pages/QuizEdit/QuizEdit';
 
 const router = createBrowserRouter([
 	{
@@ -29,6 +30,10 @@ const router = createBrowserRouter([
 			{
 				path: URL_PATH.QUIZ,
 				element: <Quiz />,
+			},
+			{
+				path: URL_PATH.QUIZ_EDIT,
+				element: <QuizEdit />,
 			},
 		],
 	},

--- a/src/style/mixin.scss
+++ b/src/style/mixin.scss
@@ -24,6 +24,11 @@
 	}
 }
 
+@mixin fontSmall {
+	font-size: v.$font-small;
+	line-height: 1.8rem;
+}
+
 @mixin fontMedium {
 	font-size: v.$font-medium;
 	line-height: 2rem;
@@ -32,4 +37,66 @@
 @mixin fontLarge {
 	font-size: v.$font-large;
 	line-height: 2.4rem;
+}
+
+@keyframes showModal {
+	0% {
+		transform: translateY(100%);
+	}
+	100% {
+		transform: translateY(0%);
+	}
+}
+
+@mixin modalBox {
+	position: fixed;
+	z-index: #{v.$modal};
+	top: auto;
+	bottom: 0;
+
+	width: 100%;
+	margin: 0 auto;
+	padding: 16px 0;
+
+	background-color: #{v.$white-100};
+	border: none;
+	border-radius: 8px;
+
+	animation: showModal 0.3s ease-out;
+
+	&::backdrop {
+		cursor: pointer;
+
+		position: fixed;
+		z-index: #{v.$modal-backdrop};
+		top: 0;
+		left: 0;
+
+		width: 100%;
+		height: 100%;
+
+		background-color: rgba(0, 0, 0, 0.25);
+	}
+}
+
+@mixin confirmButton {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 100%;
+	height: 32px;
+	border-radius: 8px;
+	font-size: 1.5rem;
+	font-weight: normal;
+	letter-spacing: 1px;
+	line-height: 2rem;
+}
+
+@mixin confirmText {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: calc(100% - 50px);
+	min-width: calc(#{v.$min-device-width} - 50px);
+	max-width: calc(#{v.$mid-device-width} - 50px);
 }

--- a/src/style/variables.scss
+++ b/src/style/variables.scss
@@ -19,6 +19,6 @@ $offcanvas: 1050;
 $modal: 1060;
 $popover: 1070;
 $tooltip: 1080;
-$font-small: 1.2rem;
+$font-small: 1.4rem;
 $font-medium: 1.6rem;
 $font-large: 2rem;

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -6,4 +6,9 @@ declare global {
 	}
 }
 
+declare module '*.scss' {
+	const content: { [className: string]: string };
+	export = content;
+}
+
 export {};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -34,7 +34,7 @@
 			"@utils/*": ["src/utils/*"],
 			"@assets/*": ["src/assets/*"],
 			"@constants/*": ["src/constants/*"],
-			"@contexts/*": ["src/contexts/*"],
+			"@context/*": ["src/context/*"],
 			"@style/*": ["src/style/*"]
 		}
 	},

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,7 +20,7 @@
 		"noUnusedParameters": true,
 		"noFallthroughCasesInSwitch": true,
 
-		"plugins": [{ "name": "typescript-plugin-css-modules" }],
+		"plugins": [{ "name": "ts-css-modules-vite-plugin" }],
 
 		"baseUrl": ".",
 		"paths": {


### PR DESCRIPTION
- [x] 퀴즈 수정 기능 구현
- [x] 토스트 기능 구현
- [x] confirm 기능 구현


### 퀴즈 수정 기능 구현

퀴즈 문제에서 상단 메뉴 > 수정하기를 클릭하면 퀴즈 수정이 가능해지도록 설정. 하지만 카테고리를 변경했을 경우에 값을 어떻게 처리해야할지가 약간 애매해 졌음. 왜냐하면 퀴즈 문제를 푸는 경우는 url에 해당 카테고리 id가 존재하는데, 카테고리가 변경되어 버리면 이번 페이지로 돌아가도 해당 id값은 존재하지 않기 때문. 따라서 이 부분은 일단 내버려 두고 있음. (카테고리 수정시에 메뉴로  돌아갈 수 있게끔 설정해볼것)

### 토스트와 confirm 컴포넌트 생성

알림을 나타내거나 사용자의 확인을 얻어야 하는 경우에 window.confirm을 사용했지만, UX나 크로스 브라우징 관련해서 기능을 좀 더 높이기 위해 추가적으로 구현