### PR TITLE
rafactor: 각족 리팩터링 모음

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -21,7 +21,8 @@
 		"**/*.ts",
 		"**/*.tsx",
 		".eslintrc.cjs",
-		"/node_modules"
+		"/node_modules",
+		"**/*.md"
 	],
 	"defaultSeverity": "warning"
 }

--- a/src/components/@common/input/input.module.scss
+++ b/src/components/@common/input/input.module.scss
@@ -4,7 +4,7 @@
 .base {
 	box-sizing: border-box;
 	width: 100%;
-	height: 32px;
+	height: 48px;
 	padding: 0 10px;
 	border: none;
 	border: 1px solid #{v.$gray-80};
@@ -24,6 +24,8 @@
 		color: #{v.$gray-80};
 		line-height: inherit !important;
 	}
+
+	@include mix.fontLarge;
 }
 
 .text {

--- a/src/components/@common/selector/selector.module.scss
+++ b/src/components/@common/selector/selector.module.scss
@@ -31,7 +31,7 @@
 	display: flex;
 	position: absolute;
 	z-index: 1080;
-	top: 32px;
+	top: 48px;
 }
 
 .input-container {

--- a/src/components/@common/toast/Toast.tsx
+++ b/src/components/@common/toast/Toast.tsx
@@ -4,7 +4,14 @@ import useToast from '@hooks/useToast';
 import styles from './toast.module.scss';
 
 const Toast = (props: ToastItem) => {
-	const { id, type, message, time = 2100 } = props;
+	const {
+		id,
+		type,
+		message,
+		time = 2100,
+		buttonContent,
+		onClickButton,
+	} = props;
 
 	const { setToastItem } = useToast();
 
@@ -42,6 +49,20 @@ const Toast = (props: ToastItem) => {
 					</div>
 				</div>
 			</div>
+			{buttonContent && onClickButton && (
+				<div>
+					<button
+						onClick={() => {
+							onClickButton();
+							toastClose();
+						}}
+						type='button'
+					>
+						{buttonContent}
+					</button>
+				</div>
+			)}
+
 			<div
 				className={`${styles['progress-bar']} ${styles[`${type}-border`]}`}
 			/>

--- a/src/components/category/categoryInput/CategoryInput.tsx
+++ b/src/components/category/categoryInput/CategoryInput.tsx
@@ -20,7 +20,7 @@ const CategoryInput = ({ category }: CategoryInputProps) => {
 				onChange={inputChangeHandler}
 			/>
 			<Button
-				size='small'
+				size='large'
 				className={styles['add-button']}
 				type='submit'
 				onClick={addCategoryHandler}

--- a/src/components/category/categoryInput/categoryInput.module.scss
+++ b/src/components/category/categoryInput/categoryInput.module.scss
@@ -3,7 +3,7 @@
 .add-category-container {
 	display: flex;
 	max-width: var(--max-device-width);
-	height: var(--button-height);
+	height: 48px;
 	@include mix.fontMedium;
 
 	gap: 8px;
@@ -11,6 +11,7 @@
 
 .add-input {
 	width: 75%;
+	height: 48px;
 }
 
 .add-button {

--- a/src/components/quiz/quizDetail/QuizDetail.tsx
+++ b/src/components/quiz/quizDetail/QuizDetail.tsx
@@ -80,7 +80,7 @@ const QuizDetail = ({ quizId, nextId }: QuizDetailProps) => {
 		updateQuiz({
 			data: {
 				...quiz,
-				favorite: !quiz.favorite,
+				favorite: Number(!quiz.favorite),
 			},
 		});
 	};

--- a/src/components/quiz/quizDetail/QuizDetail.tsx
+++ b/src/components/quiz/quizDetail/QuizDetail.tsx
@@ -86,9 +86,9 @@ const QuizDetail = ({ quizId, nextId }: QuizDetailProps) => {
 	};
 
 	return (
-		<section>
+		<section className={styles['main']}>
 			<div className={styles['quiz-container']}>
-				<p>{quiz.quiz}</p>
+				<p className={styles['paragraph']}>{quiz.quiz}</p>
 				<FavoriteButton
 					isFavorite={Boolean(quiz.favorite)}
 					onClick={favoriteClickHandler}
@@ -99,7 +99,7 @@ const QuizDetail = ({ quizId, nextId }: QuizDetailProps) => {
 				<button type='button' onClick={explainHandler}>{`해설 ${
 					explainOn ? '닫기' : '보기'
 				}`}</button>
-				{explainOn && <p>{quiz.explain}</p>}
+				{explainOn && <p className={styles['paragraph']}>{quiz.explain}</p>}
 			</div>
 
 			<div

--- a/src/components/quiz/quizDetail/quizDetail.module.scss
+++ b/src/components/quiz/quizDetail/quizDetail.module.scss
@@ -23,7 +23,7 @@
 	@include mix.fontLarge;
 
 	width: 100%;
-	overflow: scroll;
+	overflow: hidden;
 	font-size: 2rem;
 	line-height: 2.4rem;
 	overflow-wrap: break-word;

--- a/src/components/quiz/quizDetail/quizDetail.module.scss
+++ b/src/components/quiz/quizDetail/quizDetail.module.scss
@@ -1,21 +1,39 @@
 @use './../../../style/mixin' as mix;
 @use './../../../style/variables' as v;
 
+.main {
+	display: flex;
+	position: relative;
+	flex-direction: column;
+	min-height: 200px;
+	margin: 0 20px;
+	padding: 20px;
+	border: 1px solid #{v.$gray-60};
+	border-radius: 20px;
+	gap: 24px;
+}
+
 .quiz-container {
 	display: flex;
 	justify-content: space-between;
-	padding: 20px;
+	gap: 8px;
+}
 
-	p {
-		@include mix.fontLarge;
-	}
+.paragraph {
+	@include mix.fontLarge;
+
+	width: 100%;
+	overflow: scroll;
+	font-size: 2rem;
+	line-height: 2.4rem;
+	overflow-wrap: break-word;
 }
 
 .answer-container {
 	display: flex;
 	flex-direction: column;
-	padding: 20px;
 	gap: 16px;
+	margin-bottom: 40px;
 
 	button {
 		@include mix.fontLarge;
@@ -34,19 +52,25 @@
 	display: flex;
 	position: absolute;
 	bottom: 0;
+	left: 0;
 	width: 100%;
 }
 
 .button {
 	width: 100%;
 	height: #{v.$button-height};
+	height: 60px;
 	color: #{v.$white-100};
+
+	@include mix.fontMedium;
 }
 
 .false-bg {
+	border-bottom-left-radius: 20px;
 	background-color: #{v.$accent};
 }
 
 .true-bg {
+	border-bottom-right-radius: 20px;
 	background-color: #{v.$correct};
 }

--- a/src/components/quiz/quizItem/QuizItem.tsx
+++ b/src/components/quiz/quizItem/QuizItem.tsx
@@ -8,7 +8,7 @@ import FavoriteButton from '@components/@common/favoriteButton';
 
 interface QuizItemProps {
 	item: QuizListItem;
-	categoryId: number;
+	categoryId: string;
 }
 
 const QuizItem = ({ item, categoryId }: QuizItemProps) => {

--- a/src/components/quiz/quizItem/QuizItem.tsx
+++ b/src/components/quiz/quizItem/QuizItem.tsx
@@ -27,7 +27,7 @@ const QuizItem = ({ item, categoryId }: QuizItemProps) => {
 		updateQuiz({
 			data: {
 				...item,
-				favorite: !item.favorite,
+				favorite: Number(!item.favorite),
 			},
 		});
 

--- a/src/constants/path.ts
+++ b/src/constants/path.ts
@@ -17,8 +17,7 @@ export const NAVBAR_PAGE = [
 	URL_PATH.MY_PAGE,
 ];
 
-// TODO 처음 설정되는 COLLECT_ID 값을 잘 처리하기.
 export const FIRE_STORE = {
-	QUIZ: 'Quiz/data',
-	CATEGORY: 'Category',
+	QUIZ: 'quizzes',
+	CATEGORY: 'categories',
 } as const;

--- a/src/constants/path.ts
+++ b/src/constants/path.ts
@@ -21,5 +21,4 @@ export const NAVBAR_PAGE = [
 export const FIRE_STORE = {
 	QUIZ: 'Quiz/data',
 	CATEGORY: 'Category',
-	COLLECT_ID: import.meta.env.VITE_COLLECTION_ID,
 } as const;

--- a/src/constants/quiz.ts
+++ b/src/constants/quiz.ts
@@ -3,7 +3,7 @@ import type { Quiz, QuizInfo, QuizSelectFilter } from '@models/quiz';
 export const INITIAL_QUIZ: Quiz = {
 	quiz: '',
 	explain: '',
-	category: -1,
+	category: '',
 };
 
 export const INITIAL_QUIZ_RECORD: QuizInfo = {

--- a/src/fireStore/FireStore.ts
+++ b/src/fireStore/FireStore.ts
@@ -78,7 +78,6 @@ class FireStore {
 	}
 
 	async updateDocumentData(path: string, updateData: DocumentData) {
-		console.log(path, updateData);
 		const docRef = doc(this.db, path);
 
 		const currentData = await this.getDocumentInfos(`${path}`);

--- a/src/fireStore/FireStore.ts
+++ b/src/fireStore/FireStore.ts
@@ -59,11 +59,10 @@ class FireStore {
 	async getDocumentInfos(path: string) {
 		const categorySnapShot = await getDoc(doc(this.db, `${path}`));
 
-		if (categorySnapShot.exists()) {
-			return categorySnapShot.data();
-		}
+		if (!categorySnapShot.exists())
+			throw new Error('해당 경로에 맞는 데이터가 없습니다.');
 
-		throw new Error('해당 경로에 맞는 데이터가 없습니다.');
+		return categorySnapShot.data();
 	}
 
 	async getQuerySnapShot(
@@ -90,6 +89,7 @@ class FireStore {
 		setDoc(docRef, updatedData, { merge: true });
 	}
 
+	// 컬렉션 삭제를 제공하지 않음... 아...
 	async deleteDocument(path: string) {
 		const document = doc(this.db, `${path}`);
 

--- a/src/fireStore/FireStore.ts
+++ b/src/fireStore/FireStore.ts
@@ -37,7 +37,6 @@ class FireStore {
 		this.updateDocumentData = this.updateDocumentData.bind(this);
 	}
 
-	// 기존에 있던 데이터에 값을 추가하는 메서드. id가 존재하는 경우 무작위 id를 할당하고 그게 아니라면 기본 값을 할당한다.
 	async addDocumentData({
 		path = '',
 		lastId = '',
@@ -78,8 +77,8 @@ class FireStore {
 		return querySnapshot;
 	}
 
-	// Document를 업데이트 하는 메서드
 	async updateDocumentData(path: string, updateData: DocumentData) {
+		console.log(path, updateData);
 		const docRef = doc(this.db, path);
 
 		const currentData = await this.getDocumentInfos(`${path}`);
@@ -89,7 +88,6 @@ class FireStore {
 		setDoc(docRef, updatedData, { merge: true });
 	}
 
-	// 컬렉션 삭제를 제공하지 않음... 아...
 	async deleteDocument(path: string) {
 		const document = doc(this.db, `${path}`);
 

--- a/src/hooks/auth/useCurrentUser.ts
+++ b/src/hooks/auth/useCurrentUser.ts
@@ -5,7 +5,7 @@ const useCurrentUser = () => {
 	const userContext = useContext(UserContext);
 
 	if (userContext === null) {
-		throw new Error('USerProvider 내부에서 사용해주세요');
+		throw new Error('UserProvider 내부에서 사용해주세요');
 	}
 
 	/**

--- a/src/hooks/category/useCategoryInput.ts
+++ b/src/hooks/category/useCategoryInput.ts
@@ -1,20 +1,22 @@
 import { Category } from '@models/quiz';
 import { useQueryClient } from '@tanstack/react-query';
 import { useState } from 'react';
-import useUpdateDocument from '../fireStore/useUpdateDocument';
 import useConfirm from '@hooks/useConfirm';
 import useToast from '@hooks/useToast';
 import { FIRE_STORE } from '@constants/path';
+import useAddDocument from '@hooks/fireStore/useAddDocument';
 
 const useCategoryInput = (categories: Category[]) => {
 	const queryClient = useQueryClient();
+
 	const [categoryInput, setCategoryInput] = useState('');
 
 	const { addToast } = useToast();
 	const confirm = useConfirm();
 
-	const { mutate: addCategory } = useUpdateDocument({
-		path: FIRE_STORE.CATEGORY,
+	const { mutate: addCategory } = useAddDocument({
+		path: `${FIRE_STORE.CATEGORY}`,
+		lastId: `${Date.now()}`,
 		onSuccess() {
 			queryClient.invalidateQueries({
 				queryKey: [`get${FIRE_STORE.CATEGORY}`],
@@ -48,11 +50,9 @@ const useCategoryInput = (categories: Category[]) => {
 		});
 
 		if (result) {
-			const date = Date.now();
-
 			addCategory({
 				data: {
-					[date]: categoryInput,
+					name: categoryInput,
 				},
 			});
 

--- a/src/hooks/category/useGetCategory.ts
+++ b/src/hooks/category/useGetCategory.ts
@@ -1,35 +1,35 @@
-import { invariantOf } from '@utils/invariantOf';
 import useGetDocument from '../fireStore/useGetDocument';
 import type { Category } from '@models/quiz';
 import { FIRE_STORE } from '@constants/path';
 
-const useGetCategory = () =>
-	useGetDocument<Category[]>({
-		path: FIRE_STORE.CATEGORY,
+const useGetCategory = () => {
+	return useGetDocument<Category[]>({
+		path: `${FIRE_STORE.CATEGORY}`,
 		selectCallback: (data) => {
-			const convertedArray = Object.entries(invariantOf(data)) as [
-				number,
-				string
-			][];
+			if (data.empty) return [];
 
-			const convertedData = convertedArray
-				.map(([id, name]) => ({
-					id: Number(id),
-					name,
-				}))
-				.sort((a, b) => {
-					if (a.name < b.name) {
-						return -1;
-					}
+			const result: Category[] = [];
 
-					if (a.name > b.name) {
-						return 1;
-					}
-					return 0;
+			data.forEach((d) => {
+				const value = d.data();
+				result.push({
+					id: d.id,
+					name: value.name,
 				});
+			});
 
-			return convertedData;
+			return result.sort((a, b) => {
+				if (a.name < b.name) {
+					return -1;
+				}
+
+				if (a.name > b.name) {
+					return 1;
+				}
+				return 0;
+			});
 		},
 	});
+};
 
 export default useGetCategory;

--- a/src/hooks/category/useGetCategory.ts
+++ b/src/hooks/category/useGetCategory.ts
@@ -1,9 +1,9 @@
-import useGetDocument from '../fireStore/useGetDocument';
 import type { Category } from '@models/quiz';
 import { FIRE_STORE } from '@constants/path';
+import useGetSnapshot from '@hooks/fireStore/useGetSnapshot';
 
 const useGetCategory = () => {
-	return useGetDocument<Category[]>({
+	return useGetSnapshot<Category[]>({
 		path: `${FIRE_STORE.CATEGORY}`,
 		selectCallback: (data) => {
 			if (data.empty) return [];

--- a/src/hooks/category/useGetCurrentCategoryFromQuery.ts
+++ b/src/hooks/category/useGetCurrentCategoryFromQuery.ts
@@ -4,7 +4,7 @@ import { URL_PATH } from '@constants/path';
 import { useNavigate } from 'react-router-dom';
 import useGetCategory from './useGetCategory';
 
-const useGetCurrentCategoryFromQuery = (categoryId: number) => {
+const useGetCurrentCategoryFromQuery = (categoryId: string) => {
 	const navigate = useNavigate();
 
 	const goToCategoryPage = () => navigate(URL_PATH.CATEGORY, { replace: true });

--- a/src/hooks/fireStore/useAddDocument.ts
+++ b/src/hooks/fireStore/useAddDocument.ts
@@ -25,7 +25,7 @@ const useAddDocument = ({
 		mutationKey: [`add${path}${lastId}`],
 		mutationFn: ({ data }: MutateDocumentParams) =>
 			FireStore.addDocumentData({
-				path: `${user?.email}/${path}`,
+				path: `user/${user?.uid}/${path}`,
 				lastId,
 				data,
 			}),

--- a/src/hooks/fireStore/useDeleteDocument.ts
+++ b/src/hooks/fireStore/useDeleteDocument.ts
@@ -15,7 +15,7 @@ const useDeleteDocument = ({
 	return useMutation({
 		mutationKey: [`delete${path}`],
 		mutationFn: async () =>
-			await FireStore.deleteDocument(`${user?.email}/${path}`),
+			await FireStore.deleteDocument(`user/${user?.uid}/${path}`),
 		onMutate,
 		onSettled,
 		onSuccess,

--- a/src/hooks/fireStore/useGetDocument.ts
+++ b/src/hooks/fireStore/useGetDocument.ts
@@ -1,19 +1,19 @@
 import FireStore from '@fireStore/FireStore';
 import useCurrentUser from '@hooks/auth/useCurrentUser';
 import { useSuspenseQuery } from '@tanstack/react-query';
-import type { DocumentData } from 'firebase/firestore';
+import type { DocumentData, QuerySnapshot } from 'firebase/firestore';
 
 interface DocumentProps<T> {
 	path: string;
-	selectCallback?: (data: DocumentData) => T;
+	selectCallback?: (data: QuerySnapshot<DocumentData, DocumentData>) => T;
 }
 
 const useGetDocument = <T>({ path, selectCallback }: DocumentProps<T>) => {
 	const { user } = useCurrentUser();
 
-	return useSuspenseQuery<DocumentData, Error, T>({
+	return useSuspenseQuery<QuerySnapshot<DocumentData, DocumentData>, Error, T>({
 		queryKey: [`get${path}`],
-		queryFn: () => FireStore.getDocumentInfos(`${user?.email}/${path}`),
+		queryFn: () => FireStore.getQuerySnapShot(`user/${user?.uid}/${path}`, []),
 		select: selectCallback,
 	});
 };

--- a/src/hooks/fireStore/useGetDocument.ts
+++ b/src/hooks/fireStore/useGetDocument.ts
@@ -1,19 +1,19 @@
 import FireStore from '@fireStore/FireStore';
 import useCurrentUser from '@hooks/auth/useCurrentUser';
 import { useSuspenseQuery } from '@tanstack/react-query';
-import type { DocumentData, QuerySnapshot } from 'firebase/firestore';
+import type { DocumentData } from 'firebase/firestore';
 
 interface DocumentProps<T> {
 	path: string;
-	selectCallback?: (data: QuerySnapshot<DocumentData, DocumentData>) => T;
+	selectCallback?: (data: DocumentData) => T;
 }
 
 const useGetDocument = <T>({ path, selectCallback }: DocumentProps<T>) => {
 	const { user } = useCurrentUser();
 
-	return useSuspenseQuery<QuerySnapshot<DocumentData, DocumentData>, Error, T>({
+	return useSuspenseQuery<DocumentData, Error, T>({
 		queryKey: [`get${path}`],
-		queryFn: () => FireStore.getQuerySnapShot(`user/${user?.uid}/${path}`, []),
+		queryFn: () => FireStore.getDocumentInfos(`user/${user?.uid}/${path}`),
 		select: selectCallback,
 	});
 };

--- a/src/hooks/fireStore/useGetQuizList.ts
+++ b/src/hooks/fireStore/useGetQuizList.ts
@@ -51,7 +51,7 @@ const useGetQuizList = <V>(
 		queryKey = [...useGetQuizListQueryKey()];
 		if (params['category'] !== undefined) {
 			constrain.push(
-				where('category', 'in', [...params['category'].split(',')].map(Number))
+				where('category', 'in', [...params['category'].split(',')])
 			);
 		}
 		// 좋아요 확인

--- a/src/hooks/fireStore/useGetQuizList.ts
+++ b/src/hooks/fireStore/useGetQuizList.ts
@@ -93,7 +93,7 @@ const useGetQuizList = <V>(
 		queryKey: queryKey,
 		queryFn: async () => {
 			return await FireStore.getQuerySnapShot(
-				`${user?.email}/${FIRE_STORE.QUIZ}`,
+				`user/${user?.uid}/${FIRE_STORE.QUIZ}`,
 				constrain
 			);
 		},

--- a/src/hooks/fireStore/useGetSnapshot.ts
+++ b/src/hooks/fireStore/useGetSnapshot.ts
@@ -1,0 +1,21 @@
+import FireStore from '@fireStore/FireStore';
+import useCurrentUser from '@hooks/auth/useCurrentUser';
+import { useSuspenseQuery } from '@tanstack/react-query';
+import type { DocumentData, QuerySnapshot } from 'firebase/firestore';
+
+interface SnapshotProps<T> {
+	path: string;
+	selectCallback?: (data: QuerySnapshot<DocumentData, DocumentData>) => T;
+}
+
+const useGetSnapshot = <T>({ path, selectCallback }: SnapshotProps<T>) => {
+	const { user } = useCurrentUser();
+
+	return useSuspenseQuery<QuerySnapshot<DocumentData, DocumentData>, Error, T>({
+		queryKey: [`get${path}`],
+		queryFn: () => FireStore.getQuerySnapShot(`user/${user?.uid}/${path}`, []),
+		select: selectCallback,
+	});
+};
+
+export default useGetSnapshot;

--- a/src/hooks/fireStore/useUpdateDocument.ts
+++ b/src/hooks/fireStore/useUpdateDocument.ts
@@ -13,7 +13,8 @@ const useUpdateDocument = ({
 	return useMutation({
 		mutationKey: [`update${path}`],
 		mutationFn: async ({ data }: MutateDocumentParams) => {
-			await FireStore.updateDocumentData(`${user?.email}/${path}`, data);
+			console.log(`user/${user?.uid}/${path}`, data);
+			await FireStore.updateDocumentData(`user/${user?.uid}/${path}`, data);
 		},
 		onSuccess,
 		onError,

--- a/src/hooks/fireStore/useUpdateDocument.ts
+++ b/src/hooks/fireStore/useUpdateDocument.ts
@@ -13,7 +13,6 @@ const useUpdateDocument = ({
 	return useMutation({
 		mutationKey: [`update${path}`],
 		mutationFn: async ({ data }: MutateDocumentParams) => {
-			console.log(`user/${user?.uid}/${path}`, data);
 			await FireStore.updateDocumentData(`user/${user?.uid}/${path}`, data);
 		},
 		onSuccess,

--- a/src/hooks/quiz/useQuizForm.ts
+++ b/src/hooks/quiz/useQuizForm.ts
@@ -64,7 +64,7 @@ const useQuizForm = <T extends QuizInfo | QuizSelectFilter>({
 		const updateData: DocumentData = { ...quizState };
 
 		if ('favorite' in quizState) {
-			updateData['favorite'] = Boolean(quizState.favorite);
+			updateData['favorite'] = quizState.favorite ?? 0;
 		}
 
 		if ('recentCorrect' in quizState) {
@@ -72,7 +72,7 @@ const useQuizForm = <T extends QuizInfo | QuizSelectFilter>({
 		}
 
 		if ('answer' in quizState) {
-			updateData['answer'] = Boolean(quizState.answer);
+			updateData['answer'] = quizState.answer ?? 0;
 		}
 
 		submitCallback({

--- a/src/models/quiz.ts
+++ b/src/models/quiz.ts
@@ -18,14 +18,14 @@ export interface QuizInfo extends Quiz {
 }
 
 export type QuizSelectFilter = Pick<QuizInfo, 'correctRate'> & {
-	category: number[];
+	category: string[];
 	isFirst?: UserAnswer;
 	favorite?: UserAnswer;
 	recentCorrect?: UserAnswer;
 };
 
 export type Category = {
-	id: number;
+	id: string;
 	name: string;
 };
 

--- a/src/pages/Auth/MyPage.tsx
+++ b/src/pages/Auth/MyPage.tsx
@@ -5,21 +5,36 @@ import useConfirm from '@hooks/useConfirm';
 import { deleteUser } from 'firebase/auth';
 import { useNavigate } from 'react-router-dom';
 import styles from './auth.module.scss';
+import FireStore from '@fireStore/FireStore';
+import useCurrentUser from '@hooks/auth/useCurrentUser';
 
 const MyPage = () => {
 	const navigate = useNavigate();
 	const confirm = useConfirm();
 
+	const { user } = useCurrentUser();
+
 	const signOutHandler = () => {
 		auth.signOut();
 	};
 
+	/**
+	 * TODO:
+	 * 사용자 데이터 저장하는데 있어서 구조 문제가 분명히 존재한다.
+	 *
+	 * 따라서 기존 user > uid > Quiz > 문서
+	 * user > uid > Category > 문서 이렇게 갈지,
+	 * 아니면 uid[category] = {} > 이렇게 갈지 고민
+	 *
+	 *
+	 */
 	const deleteUserHandler = async () => {
-		if (!auth.currentUser) return;
-		const result = await confirm({ message: '정말 탈퇴하시겠어요?' });
+		if (!user) return;
 
+		const result = await confirm({ message: '정말 탈퇴하시겠어요?' });
 		if (result) {
-			await deleteUser(auth.currentUser);
+			await deleteUser(user);
+			await FireStore.deleteDocument(`user/${user.uid}`);
 			navigate(URL_PATH.LOGIN, { replace: true });
 		}
 	};

--- a/src/pages/Auth/MyPage.tsx
+++ b/src/pages/Auth/MyPage.tsx
@@ -18,16 +18,6 @@ const MyPage = () => {
 		auth.signOut();
 	};
 
-	/**
-	 * TODO:
-	 * 사용자 데이터 저장하는데 있어서 구조 문제가 분명히 존재한다.
-	 *
-	 * 따라서 기존 user > uid > Quiz > 문서
-	 * user > uid > Category > 문서 이렇게 갈지,
-	 * 아니면 uid[category] = {} > 이렇게 갈지 고민
-	 *
-	 *
-	 */
 	const deleteUserHandler = async () => {
 		if (!user) return;
 

--- a/src/pages/CategoryDetail/CategoryDetail.tsx
+++ b/src/pages/CategoryDetail/CategoryDetail.tsx
@@ -12,7 +12,7 @@ const CategoryDetail = () => {
 	const params = useParams();
 
 	const { category, goToCategoryPage } = useGetCurrentCategoryFromQuery(
-		Number(params.id ?? 0)
+		params.id ?? ''
 	);
 
 	if (!category) {

--- a/src/pages/CategoryDetail/CategoryDetail.tsx
+++ b/src/pages/CategoryDetail/CategoryDetail.tsx
@@ -63,7 +63,7 @@ const CategoryDetail = () => {
 			<main>
 				{quizList.length === 0 ? (
 					<div className={styles['empty-container']}>
-						<p>아직 등록된 문젝가 없습니다</p>
+						<p>아직 등록된 문제가 없습니다</p>
 						<Link className={styles['form-link']} to={URL_PATH.QUIZ_FORM}>
 							등록하러 가기
 						</Link>

--- a/src/pages/Quiz/Quiz.tsx
+++ b/src/pages/Quiz/Quiz.tsx
@@ -19,6 +19,8 @@ const Quiz = () => {
 
 	const { data: quizIds } = useGetQuizList<QuizInfo['id'][]>({
 		selectHandler: (data) => {
+			if (data.empty) return [];
+
 			const result: QuizInfo['id'][] = [];
 
 			data.forEach((value) => {

--- a/src/pages/Quiz/Quiz.tsx
+++ b/src/pages/Quiz/Quiz.tsx
@@ -32,6 +32,9 @@ const Quiz = () => {
 		quizIds,
 	});
 
+	const currentIndex = quizIds.findIndex((id) => id === currentId);
+	const nextId = quizIds[currentIndex + 1] ?? null;
+
 	return (
 		<main className={styles.main}>
 			<Header
@@ -50,7 +53,7 @@ const Quiz = () => {
 				}
 			/>
 			<QuizNavbar currentId={currentId} quizIds={quizIds} />
-			<QuizDetail quizId={currentId} />
+			<QuizDetail quizId={currentId} nextId={nextId} />
 		</main>
 	);
 };

--- a/src/pages/Quiz/Quiz.tsx
+++ b/src/pages/Quiz/Quiz.tsx
@@ -7,6 +7,8 @@ import useLocationQueryParams from '@hooks/useLocationQueryParams';
 import { QUIZ_PARAMS } from '@constants/quiz';
 import useGetQuizList from '@hooks/fireStore/useGetQuizList';
 import { QuizInfo } from '@models/quiz';
+import { Navigate, generatePath } from 'react-router-dom';
+import { URL_PATH } from '@constants/path';
 
 const { quiz } = QUIZ_PARAMS;
 
@@ -31,6 +33,16 @@ const Quiz = () => {
 		currentId,
 		quizIds,
 	});
+
+	if (quizIds.length === 0) {
+		const categoryId = getQueryParam('category');
+
+		return (
+			<Navigate
+				to={generatePath(URL_PATH.CATEGORY_DETAIL, { id: categoryId })}
+			/>
+		);
+	}
 
 	const currentIndex = quizIds.findIndex((id) => id === currentId);
 	const nextId = quizIds[currentIndex + 1] ?? null;


### PR DESCRIPTION
- [x] "등록된 문제가 없습니다" 안내 문구를 수정한다
- [x]  사용자 회원가입시 값을 업데이트 한다.
- [x]  문제를 풀었을 경우에 다음 문제로 이동하기를 추가한다
- [x]  o,x 버튼 위치를 조정한다
- [ ]  이미 설치된 경우에 prompt 안내를 보여주지 않는다

---

### DB 구조 변경

원래는 사용자의 email > category, quiz 등으로 최하단에 사용자 개인의 컬렉션을 만들어서 데이터에 접근하는 형식이었지만, 회원 탈퇴를 할 때 [컬렉션을 삭제할 수 없는 문제](https://firebase.google.com/docs/firestore/manage-data/delete-data?hl=ko&_gl=1*mn1vja*_up*MQ..*_ga*MTI1NTQ5MTk3Ni4xNzA5MTI1ODY2*_ga_CW55HF8NVT*MTcwOTIwOTkzMy4zLjAuMTcwOTIwOTk1MC4wLjAuMA..#collections)에 부딪혔습니다. 

따라서 사용자가 로그인 혹은 회원가입 했을 경우 사용자의 uid로 문서를 만들고 문서 id를 기반으로 collection을 생성해서 접근하는 방식으로 DB구조를 변경했습니다.

### 퀴즈 UI 변경

퀴즈 정답 입력 버튼이 너무 아래있다는 불편사항이 접수되어서 하나의 Box로 만들고 그 내부에 답을 입력할 수 있게끔 변경했습니다.
![image](https://github.com/hozzijeong/oxnote/assets/50974359/9d0a9257-1bd6-4fa1-a7e7-7dc7fe8d992b)

### 문제 풀었을 경우에 다음 문제로 이동하는 버튼 생성

문제를 풀고 난 다음에 다음 문제로 넘어가기 위해서 상단에 있는 navbar를 사용해야하는 불편함이 있었는데 toast에 다음 문제 버튼을 추가했습니다


